### PR TITLE
Remove useless check in kb creation test

### DIFF
--- a/cypress/e2e/1-basic/2-kb-creation-flow.cy.js
+++ b/cypress/e2e/1-basic/2-kb-creation-flow.cy.js
@@ -15,8 +15,7 @@ describe('KB creation flow', () => {
     cy.get('app-kb-add [formcontrolname="description"] textarea').type('Some kb');
     cy.get('app-kb-add').contains('Next').click();
     cy.get('app-kb-add').contains('Save').click();
-    cy.get('.account-kbs-list .account-kb', { timeout: 10000 }).should('have.length', 2);
-    cy.get(`a[href="/at/testing/${KB_NAME}"]`).should('contain', KB_NAME);
+    cy.get(`a[href="/at/testing/${KB_NAME}"]`, { timeout: 10000 }).should('contain', KB_NAME);
     cy.get(`a[href="/at/testing/${KB_NAME}"]`).click();
     cy.location('pathname').should('equal', `/at/testing/${KB_NAME}`);
     cy.get('app-kb-switch').should('contain', KB_NAME);


### PR DESCRIPTION
We were checking if after creation the list of KB had a length of 2, while after the addition the list should contain 3 KB. This check was passing because the creation is a bit slow and also because we use to start with 1 KB (while we now have 2 kbs). In this PR we remove the wrong check. What is important is  the newly created KB appears in the list after creation, not how many kbs there are in the list. This test is now more robust and future-proof (we can add more KBs without risking breaking this test).