### PR TITLE
Add a check in resource classification test

### DIFF
--- a/cypress/e2e/1-basic/1-resources.cy.js
+++ b/cypress/e2e/1-basic/1-resources.cy.js
@@ -132,6 +132,7 @@ describe('Resources', () => {
           cy.contains('Heroes').click();
           cy.contains('Catwoman').click();
           cy.get('body').type('{esc}');
+          cy.get('.label-list pa-chip-closeable').should('have.length', 2);
           cy.contains('Save').click();
           cy.get('.pa-toast-wrapper').should('contain', 'Resource saved');
           cy.request({


### PR DESCRIPTION
We currently have some flakiness on this classification test. This check should allow us to detect flakiness more easily.