### PR TITLE
Change name of KB created during tests

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -25,7 +25,7 @@ module.exports = defineConfig({
       require('cypress-mochawesome-reporter/plugin')(on);
     },
     env: {
-      KB_NAME: 'local'
+      KB_NAME: 'cypress'
     }
   }
 });


### PR DESCRIPTION
Currently, the backend is failing when we try to create a KB named `new-kb-local`. There's some cleanup and checks to be done on the backend side, so in the meantime let's change the KB name to prevent e2e test failure coming from this name.