### PR TITLE
Prevent embedded preview on GH action failure message

### DIFF
--- a/.github/workflows/run-e2e.yml
+++ b/.github/workflows/run-e2e.yml
@@ -44,5 +44,5 @@ jobs:
           webhook: ${{ secrets.DISCORD_WEBHOOK_APPLICATION }}
           message: |
             ⚠️ tests failed
-            ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}>
           username: 'Cypress E2E'


### PR DESCRIPTION
Wrap link to GH action job into `<>` to prevent embedded preview of the link.