### PR TITLE
Fix e2e broken by [sc-7748]

### DIFF
--- a/cypress/e2e/0-user/2-auth.cy.js
+++ b/cypress/e2e/0-user/2-auth.cy.js
@@ -21,7 +21,7 @@ describe('User Login', () => {
     cy.visit('/');
     cy.get(`[formcontrolname="email"] input`).type(user.email,{ log: false });
     cy.get(`[data-cy="password"] input[type="password"]`).type(`${user.password}{enter}`,{ log: false });
-    cy.get('a[href="/at/testing/permanent"]').click();
+    cy.get('a').contains('permanent').click();
     cy.location('pathname').should('equal', '/at/testing/permanent');
     cy.get(`.knowledge-box-home .endpoint-container`).should('contain', 'NucliaDB API endpoint')
 


### PR DESCRIPTION
In [sc-7748] we removed the actual link from the template in KB selection page because the account is now an observable which made it difficult to build the KB url directly in the template.