### PR TITLE
Prepare GH Action configuration for running e2e in prod

### DIFF
--- a/.github/workflows/run-e2e-nua-prod.yml
+++ b/.github/workflows/run-e2e-nua-prod.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
   schedule:
-    # run every at every saturdat at 12
+    # run at 04:25 on Saturday
     - cron: '25 4 * * 6'
 jobs:
   test:

--- a/.github/workflows/run-e2e-nua-stage.yml
+++ b/.github/workflows/run-e2e-nua-stage.yml
@@ -8,7 +8,7 @@ on:
     branches:
       - main
   schedule:
-    # run every at every saturdat at 12
+    # run every day at 04:25
     - cron: '25 4 * * *'
 jobs:
   test:

--- a/.github/workflows/run-e2e-prod.yml
+++ b/.github/workflows/run-e2e-prod.yml
@@ -1,17 +1,15 @@
-name: run-e2e
-run-name: Running e2e tests
+name: run-e2e-prod
+run-name: Running e2e tests on prod
 on:
   push:
     branches:
-      - '**'
+      - e2e-on-prod
   workflow_dispatch:
     branches:
-      - main
+      - e2e-on-prod
   schedule:
-    # run every day at every minute 25 of every hour monday to friday
-    - cron: '25 * * * 1-5'
-      # run at 00:25 and 12:25 on saturday and sunday
-    - cron: '25 0,12 * * 0,6'
+    # Run at minute 15 past every 3rd hour on every day-of-week from Sunday through Saturday.
+    - cron: '15 */3 * * 0-6'
 jobs:
   cypress-run:
     runs-on: ubuntu-22.04
@@ -24,8 +22,7 @@ jobs:
           docker build -t nucliadb-server .
           docker run -p 8080:8080 \
               -v nucliadb-standalone:/data \
-              -e NUCLIA_PUBLIC_URL="https://{zone}.stashify.cloud" \
-              -e NUA_API_KEY=${{ secrets.NUA_KEY }} \
+              -e NUA_API_KEY=${{ secrets.NUA_KEY_PROD }} \
               nucliadb-server &
       # Install npm dependencies, cache them correctly and run all Cypress tests
       - name: Cypress run
@@ -34,10 +31,10 @@ jobs:
         with:
           install-command: yarn install
         env:
-          CYPRESS_BEARER_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-          CYPRESS_NUA_KEY: ${{ secrets.NUA_KEY }}
-          CYPRESS_USER_NAME: ${{ secrets.USER_NAME }}
-          CYPRESS_USER_PWD: ${{ secrets.USER_PWD }}
+          CYPRESS_BEARER_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN_PROD }}
+          CYPRESS_NUA_KEY: ${{ secrets.NUA_KEY_PROD }}
+          CYPRESS_USER_NAME: ${{ secrets.USER_NAME_PROD }}
+          CYPRESS_USER_PWD: ${{ secrets.USER_PWD_PROD }}
         # after the test run completes store reports and any screenshots
       - name: Cypress reports
         uses: actions/upload-artifact@v3
@@ -53,7 +50,7 @@ jobs:
         with:
           payload: |
             {
-              "text": "⚠️ tests failed\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              "text": "‼️⚠️ tests failed on Prod ‼️\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_HOOK_URL }}

--- a/.github/workflows/run-e2e-stage.yml
+++ b/.github/workflows/run-e2e-stage.yml
@@ -1,0 +1,64 @@
+name: run-e2e-stage
+run-name: Running e2e tests on Stage
+on:
+  push:
+    branches:
+      - '**'
+  workflow_dispatch:
+    branches:
+      - main
+  schedule:
+    # Run at minute 25 past every hour from 7 through 23 on Monday.
+    - cron: 25 7-23 * * 1
+    # Run at minute 25 on every day-of-week from Tuesday through Thursday.
+    - cron: '25 * * * 2-4'
+    # Run at minute 25 past every hour from 0 through 19 on Friday.
+    - cron: 25 0-19 * * 5
+    # Run at 00:25 and 12:25 on saturday and sunday
+    - cron: '25 0,12 * * 0,6'
+jobs:
+  cypress-run:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      # Launch NucliaDB in docker
+      - run: |
+          docker pull nuclia/nucliadb:latest
+          docker build -t nucliadb-server .
+          docker run -p 8080:8080 \
+              -v nucliadb-standalone:/data \
+              -e NUCLIA_PUBLIC_URL="https://{zone}.stashify.cloud" \
+              -e NUA_API_KEY=${{ secrets.NUA_KEY }} \
+              nucliadb-server &
+      # Install npm dependencies, cache them correctly and run all Cypress tests
+      - name: Cypress run
+        id: cypress
+        uses: cypress-io/github-action@v6
+        with:
+          install-command: yarn install
+        env:
+          CYPRESS_BEARER_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          CYPRESS_NUA_KEY: ${{ secrets.NUA_KEY }}
+          CYPRESS_USER_NAME: ${{ secrets.USER_NAME }}
+          CYPRESS_USER_PWD: ${{ secrets.USER_PWD }}
+        # after the test run completes store reports and any screenshots
+      - name: Cypress reports
+        uses: actions/upload-artifact@v3
+        if: ${{ failure() && steps.cypress.conclusion == 'failure' }}
+        with:
+          name: cypress-reports
+          path: cypress/reports
+          if-no-files-found: ignore # 'warn' or 'error' are also available, defaults to `warn`
+      - name: Slack notification
+        id: slack
+        uses: slackapi/slack-github-action@v1.24.0
+        if: ${{ failure() && steps.cypress.conclusion == 'failure' && github.ref_name == 'main' }}
+        with:
+          payload: |
+            {
+              "text": "⚠️ tests failed on Stage\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_HOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK


### PR DESCRIPTION
This PR is just a first step of splitting the GH action configuration in two, so we can run e2e on prod. Once this PR will be merged, we will create a branch `e2e-on-prod` which will have specific cypress configuration for prod, as well as tests on US zone.