### PR TITLE
[sc-9018] Ability to run e2e tests on several zones and accounts

### DIFF
--- a/.github/workflows/run-e2e-prod.yml
+++ b/.github/workflows/run-e2e-prod.yml
@@ -22,7 +22,7 @@ jobs:
           docker build -t nucliadb-server .
           docker run -p 8080:8080 \
               -v nucliadb-standalone:/data \
-              -e NUA_API_KEY=${{ secrets.NUA_KEY_PROD }} \
+              -e NUA_API_KEY=${{ secrets.NUA_KEY_PROD_EUROPE }} \
               nucliadb-server &
       # Install npm dependencies, cache them correctly and run all Cypress tests
       - name: Cypress run
@@ -32,9 +32,11 @@ jobs:
           install-command: yarn install
         env:
           CYPRESS_BEARER_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN_PROD }}
-          CYPRESS_NUA_KEY: ${{ secrets.NUA_KEY_PROD }}
+          CYPRESS_NUA_KEY_EUROPE: ${{ secrets.NUA_KEY_PROD_EUROPE }}
+          CYPRESS_NUA_KEY_USA: ${{ secrets.NUA_KEY_PROD_USA }}
           CYPRESS_USER_NAME: ${{ secrets.USER_NAME_PROD }}
           CYPRESS_USER_PWD: ${{ secrets.USER_PWD_PROD }}
+          CYPRESS_RUNNING_ENV: prod
         # after the test run completes store reports and any screenshots
       - name: Cypress reports
         uses: actions/upload-artifact@v3

--- a/.github/workflows/run-e2e-stage.yml
+++ b/.github/workflows/run-e2e-stage.yml
@@ -42,6 +42,7 @@ jobs:
           CYPRESS_NUA_KEY: ${{ secrets.NUA_KEY }}
           CYPRESS_USER_NAME: ${{ secrets.USER_NAME }}
           CYPRESS_USER_PWD: ${{ secrets.USER_PWD }}
+          CYPRESS_RUNNING_ENV: stage
         # after the test run completes store reports and any screenshots
       - name: Cypress reports
         uses: actions/upload-artifact@v3

--- a/cypress/e2e/0-user/auth.cy.js
+++ b/cypress/e2e/0-user/auth.cy.js
@@ -1,6 +1,6 @@
 /// <reference types="cypress" />
 
-import { user } from '../../support/common';
+import { ACCOUNT, permanentKb, user } from '../../support/common';
 
 describe('User Login', () => {
   it('should redirect unauthenticated user to login page', function() {
@@ -14,15 +14,15 @@ describe('User Login', () => {
     cy.get(`[formcontrolname="email"] input`).type(user.email,{ log: false });
     cy.get(`[data-cy="password"] input[type="password"]`).type(user.password,{ log: false });
     cy.get(`button[type='submit']`).click();
-    cy.location('pathname').should('equal', '/select/testing');
+    cy.location('pathname').should('equal', `/select/${ACCOUNT.slug}`);
   });
 
   it('should allow a visitor to login and logout', () => {
     cy.visit('/');
     cy.get(`[formcontrolname="email"] input`).type(user.email,{ log: false });
     cy.get(`[data-cy="password"] input[type="password"]`).type(`${user.password}{enter}`,{ log: false });
-    cy.get('a').contains('permanent').click();
-    cy.location('pathname').should('equal', '/at/testing/europe-1/permanent');
+    cy.get('a').contains(permanentKb.name).click();
+    cy.location('pathname').should('equal', `/at/${ACCOUNT.slug}/${permanentKb.zone}/${permanentKb.slug}`);
     cy.get(`.kb-details .title-xxs`).should('contain', 'NucliaDB API endpoint')
 
     // logout

--- a/cypress/e2e/0-user/auth.cy.js
+++ b/cypress/e2e/0-user/auth.cy.js
@@ -1,6 +1,6 @@
 /// <reference types="cypress" />
 
-import { ACCOUNT, permanentKb, user } from '../../support/common';
+import { ACCOUNT, user } from '../../support/common';
 
 describe('User Login', () => {
   it('should redirect unauthenticated user to login page', function() {
@@ -18,6 +18,7 @@ describe('User Login', () => {
   });
 
   it('should allow a visitor to login and logout', () => {
+    const permanentKb = ACCOUNT.availableZones[0].permanentKb;
     cy.visit('/');
     cy.get(`[formcontrolname="email"] input`).type(user.email,{ log: false });
     cy.get(`[data-cy="password"] input[type="password"]`).type(`${user.password}{enter}`,{ log: false });

--- a/cypress/e2e/1-basic/kb-creation-flow.cy.js
+++ b/cypress/e2e/1-basic/kb-creation-flow.cy.js
@@ -1,6 +1,6 @@
 /// <reference types="cypress" />
 
-import { goTo, goToManageAccount, onlyPermanentKb } from '../../support/common';
+import { ACCOUNT, goTo, goToManageAccount, onlyPermanentKb, ZONES } from '../../support/common';
 
 describe('KB creation flow', () => {
   before(() => {
@@ -21,7 +21,7 @@ describe('KB creation flow', () => {
     cy.get('app-kb-add').contains('Save').click();
     cy.get(`[data-cy="${newKbName}-link"]`, { timeout: 10000 }).should('contain', newKbName);
     cy.get(`[data-cy="${newKbName}-link"]`).click();
-    cy.location('pathname').should('equal', `/at/testing/europe-1/${newKbName}`);
+    cy.location('pathname').should('equal', `/at/${ACCOUNT.slug}/${ZONES['europe']}/${newKbName}`);
     cy.get('app-kb-switch').should('contain', newKbName);
 
     // Deletion test

--- a/cypress/e2e/1-basic/kb-creation-flow.cy.js
+++ b/cypress/e2e/1-basic/kb-creation-flow.cy.js
@@ -1,35 +1,38 @@
 /// <reference types="cypress" />
 
-import { ACCOUNT, goTo, goToManageAccount, onlyPermanentKb, ZONES } from '../../support/common';
+import { ACCOUNT, goTo, goToManageAccount, onlyPermanentKb } from '../../support/common';
 
 describe('KB creation flow', () => {
   before(() => {
     onlyPermanentKb();
   });
 
-  it('should allow to create a new kb and then delete it', () => {
-    const newKbName = `new-kb-${Date.now()}`;
-    cy.login();
+  ACCOUNT.availableZones.forEach((zone) => {
+    it(`should allow to create a new kb and then delete it on ${zone.slug}`, () => {
+      const newKbName = `new-kb-${Date.now()}`;
+      cy.login(zone);
 
-    // creation test
-    goToManageAccount();
-    goTo('go-to-account-kbs');
-    cy.get('[data-cy="add-kb"]').click();
-    cy.get('app-kb-add [formcontrolname="title"] input').type(newKbName);
-    cy.get('app-kb-add [formcontrolname="description"] textarea').type('Some kb');
-    cy.get('app-kb-add').contains('Next').click();
-    cy.get('app-kb-add').contains('Save').click();
-    cy.get(`[data-cy="${newKbName}-link"]`, { timeout: 10000 }).should('contain', newKbName);
-    cy.get(`[data-cy="${newKbName}-link"]`).click();
-    cy.location('pathname').should('equal', `/at/${ACCOUNT.slug}/${ZONES['europe']}/${newKbName}`);
-    cy.get('app-kb-switch').should('contain', newKbName);
+      // creation test
+      goToManageAccount();
+      goTo('go-to-account-kbs');
+      cy.get('[data-cy="add-kb"]').click();
+      cy.get('app-kb-add [formcontrolname="title"] input').type(newKbName);
+      cy.get('app-kb-add [formcontrolname="description"] textarea').type('Some kb');
+      cy.get('app-kb-add').contains('Next').click();
+      cy.get('app-kb-add').contains('Save').click();
+      cy.get(`[data-cy="${newKbName}-link"]`, { timeout: 10000 }).should('contain', newKbName);
+      cy.get(`[data-cy="${newKbName}-link"]`).click();
+      cy.location('pathname').should('equal', `/at/${ACCOUNT.slug}/${zone.slug}/${newKbName}`);
+      cy.get('app-kb-switch').should('contain', newKbName);
 
-    // Deletion test
-    goToManageAccount();
-    goTo('go-to-account-kbs');
-    cy.get(`[data-cy="${newKbName}-link"]`).contains(newKbName);
-    cy.get(`[data-cy="${newKbName}-delete"]`).click();
-    cy.get('[qa="confirmation-dialog-confirm-button"]').click();
-    cy.get('.account-kbs-list .account-kb').should('have.length', 2);
+      // Deletion test
+      goToManageAccount();
+      goTo('go-to-account-kbs');
+      cy.get(`[data-cy="${newKbName}-link"]`).contains(newKbName);
+      cy.get(`[data-cy="${newKbName}-delete"]`).click();
+      cy.get('[qa="confirmation-dialog-confirm-button"]').click();
+      cy.get('.account-kbs-list .account-kb').should('have.length', 2);
+    });
   });
+
 });

--- a/cypress/e2e/1-basic/kb-settings.cy.js
+++ b/cypress/e2e/1-basic/kb-settings.cy.js
@@ -1,36 +1,39 @@
 /// <reference types="cypress" />
 
-import { ACCOUNT, emptyKb, getAuthHeader, goTo, ZONES } from '../../support/common';
+import { ACCOUNT, getAuthHeader, goTo } from '../../support/common';
 
 describe('Change KB settings', () => {
-  const endpoint = `https://${ZONES['europe']}.${ACCOUNT.domain}/api/v1/account/${ACCOUNT.id}/kb/${emptyKb.id}`;
   const authHeader = getAuthHeader();
 
-  before(() => {
-    cy.request({
-      method: 'PATCH',
-      url: `${endpoint}`,
-      headers: authHeader,
-      body: {
-        description: `DO NOT DELETE\nKnowledge box used to test content addition through E2E tests, and should always be empty at the end of the tests`,
-      },
-    }).then((response) => {
-      expect(response.status).to.eq(200);
-    });
-  });
+  ACCOUNT.availableZones.forEach((zone) => {
+    const endpoint = `https://${zone.slug}.${ACCOUNT.domain}/api/v1/account/${ACCOUNT.id}/kb/${zone.emptyKb.id}`;
 
-  it('should allow to change the kb settings', () => {
-    cy.loginToEmptyKb();
-    goTo('go-to-advanced');
-    goTo('go-to-settings');
-    cy.get('.dashboard-content').scrollTo('bottom');
-    cy.get('[data-cy="save-kb-settings"]').get('button').should('be.disabled');
-    cy.get('.dashboard-content').scrollTo('top');
-    cy.get(`[formcontrolname="description"] textarea`).type(
-      '\nWhy did you say that? Now I feel like I want to delete this kb.\n'
-    );
-    cy.get('.dashboard-content').scrollTo('bottom');
-    cy.get('[data-cy="save-kb-settings"]').click();
-    cy.get('.pa-toast-wrapper').should('contain', 'The new settings have been saved successfully');
+    before(() => {
+      cy.request({
+        method: 'PATCH',
+        url: `${endpoint}`,
+        headers: authHeader,
+        body: {
+          description: `DO NOT DELETE\nKnowledge box used to test content addition through E2E tests, and should always be empty at the end of the tests`,
+        },
+      }).then((response) => {
+        expect(response.status).to.eq(200);
+      });
+    });
+
+    it(`should allow to change the kb settings on ${zone.slug}`, () => {
+      cy.loginToEmptyKb(zone);
+      goTo('go-to-advanced');
+      goTo('go-to-settings');
+      cy.get('.dashboard-content').scrollTo('bottom');
+      cy.get('[data-cy="save-kb-settings"]').get('button').should('be.disabled');
+      cy.get('.dashboard-content').scrollTo('top');
+      cy.get(`[formcontrolname="description"] textarea`).type(
+        '\nWhy did you say that? Now I feel like I want to delete this kb.\n'
+      );
+      cy.get('.dashboard-content').scrollTo('bottom');
+      cy.get('[data-cy="save-kb-settings"]').click();
+      cy.get('.pa-toast-wrapper').should('contain', 'The new settings have been saved successfully');
+    });
   });
 });

--- a/cypress/e2e/1-basic/kb-settings.cy.js
+++ b/cypress/e2e/1-basic/kb-settings.cy.js
@@ -1,9 +1,9 @@
 /// <reference types="cypress" />
 
-import { ACCOUNT, emptyKb, getAuthHeader, goTo } from '../../support/common';
+import { ACCOUNT, emptyKb, getAuthHeader, goTo, ZONES } from '../../support/common';
 
 describe('Change KB settings', () => {
-  const endpoint = `https://europe-1.stashify.cloud/api/v1/account/${ACCOUNT.id}/kb/${emptyKb.id}`;
+  const endpoint = `https://${ZONES['europe']}.${ACCOUNT.domain}/api/v1/account/${ACCOUNT.id}/kb/${emptyKb.id}`;
   const authHeader = getAuthHeader();
 
   before(() => {

--- a/cypress/e2e/1-basic/manage-content.cy.js
+++ b/cypress/e2e/1-basic/manage-content.cy.js
@@ -1,6 +1,6 @@
 /// <reference types="cypress" />
 
-import { ACCOUNT, emptyKb, getAuthHeader, goTo, ZONES } from '../../support/common';
+import { ACCOUNT, ACCOUNT_STAGE, getAuthHeader, goTo } from '../../support/common';
 
 function checkResourceWasAdded(endpoint, resourceTitle) {
   cy.request({
@@ -15,88 +15,91 @@ function checkResourceWasAdded(endpoint, resourceTitle) {
 }
 
 describe('Manage content', () => {
-  const endpoint = `https://${ZONES['europe']}.${ACCOUNT.domain}/api/v1/kb/${emptyKb.id}`;
   const authHeader = getAuthHeader();
 
-  before(() => {
-    // clean up resources
-    cy.request({
-      method: 'GET',
-      url: `${endpoint}/resources`,
-      headers: authHeader
-    }).then(response => {
-      expect(response.status).to.eq(200);
-      const resourceCount = response.body['resources'].length;
-      if (resourceCount > 0) {
-        // This will be output to terminal
-        cy.task('log', `Delete ${resourceCount} resources from previous tests`);
-        response.body['resources'].forEach(resource => {
-          cy.request({
-            method: 'DELETE',
-            url: `${endpoint}/resource/${resource.id}`,
-            headers: authHeader
-          }).then(deleteResponse => expect(deleteResponse.status).to.eq(204));
-        });
-      }
-    });
-  });
+  ACCOUNT_STAGE.availableZones.forEach((zone) => {
+    const endpoint = `https://${zone.slug}.${ACCOUNT.domain}/api/v1/kb/${zone.emptyKb.id}`;
 
-  it('should use the API to upload a file', () => {
-    cy.request({
-      method: 'POST',
-      url: `${endpoint}/resources`,
-      headers: {
-        ...authHeader,
-        'x-synchronous': 'true'
-      },
-      body: {
-        title: 'hello.txt'
-      }
-    }).then(resourceResponse => {
-      expect(resourceResponse.status).to.eq(201);
-      const resourceId = resourceResponse.body.uuid;
-      cy.fixture('hello.txt').then(file => cy.request({
+    before(() => {
+      // clean up resources
+      cy.request({
+        method: 'GET',
+        url: `${endpoint}/resources`,
+        headers: authHeader
+      }).then(response => {
+        expect(response.status).to.eq(200);
+        const resourceCount = response.body['resources'].length;
+        if (resourceCount > 0) {
+          // This will be output to terminal
+          cy.task('log', `Delete ${resourceCount} resources from previous tests`);
+          response.body['resources'].forEach(resource => {
+            cy.request({
+              method: 'DELETE',
+              url: `${endpoint}/resource/${resource.id}`,
+              headers: authHeader
+            }).then(deleteResponse => expect(deleteResponse.status).to.eq(204));
+          });
+        }
+      });
+    });
+
+    it(`should use the API to upload a file on ${zone.slug}`, () => {
+      cy.request({
         method: 'POST',
-        url: `${endpoint}/resource/${resourceId}/file/hello/upload`,
+        url: `${endpoint}/resources`,
         headers: {
           ...authHeader,
-          'x-md5': ['8b1a9953c4611296a827abf8c47804d7'],
           'x-synchronous': 'true'
         },
-        body: file
-      }).then((resp) => {
-        expect(resp.status).to.eq(201);
-        checkResourceWasAdded(endpoint, 'hello.txt');
-      }));
+        body: {
+          title: 'hello.txt'
+        }
+      }).then(resourceResponse => {
+        expect(resourceResponse.status).to.eq(201);
+        const resourceId = resourceResponse.body.uuid;
+        cy.fixture('hello.txt').then(file => cy.request({
+          method: 'POST',
+          url: `${endpoint}/resource/${resourceId}/file/hello/upload`,
+          headers: {
+            ...authHeader,
+            'x-md5': ['8b1a9953c4611296a827abf8c47804d7'],
+            'x-synchronous': 'true'
+          },
+          body: file
+        }).then((resp) => {
+          expect(resp.status).to.eq(201);
+          checkResourceWasAdded(endpoint, 'hello.txt');
+        }));
+      });
     });
-  });
 
-  it('should upload content from the UI', () => {
-    cy.loginToEmptyKb();
-    goTo('go-to-upload');
+    it(`should upload content from the UI on ${zone.slug}`, () => {
+      cy.loginToEmptyKb(zone);
+      goTo('go-to-upload');
 
-    // Upload file
-    cy.task('log', 'Upload file');
+      // Upload file
+      cy.task('log', 'Upload file');
 
-    cy.get('stf-upload-option[icon="file"]').click();
+      cy.get('stf-upload-option[icon="file"]').click();
 
-    cy.get('#upload-file-chooser').attachFile('nuclia-logo.png');
-    cy.get('app-upload-files').contains('Add').click();
-    cy.get('pa-modal-title').contains('Upload queue').should('exist');
-    cy.get('.status pa-icon[name="check"]', { timeout: 10000 }).should('exist');
-    cy.get('app-upload-progress button[aria-label="Close"]').click();
-    cy.get('.pa-toast-wrapper').should('contain', 'Upload successful');
-    cy.location('pathname').should('equal', `/at/${ACCOUNT.slug}/${emptyKb.zone}/${emptyKb.name}/resources/pending`);
+      cy.get('#upload-file-chooser').attachFile('nuclia-logo.png');
+      cy.get('app-upload-files').contains('Add').click();
+      cy.get('pa-modal-title').contains('Upload queue').should('exist');
+      cy.get('.status pa-icon[name="check"]', { timeout: 10000 }).should('exist');
+      cy.get('app-upload-progress button[aria-label="Close"]').click();
+      cy.get('.pa-toast-wrapper').should('contain', 'Upload successful');
+      cy.location('pathname').should('equal', `/at/${ACCOUNT.slug}/${zone.emptyKb.zone}/${zone.emptyKb.name}/resources/pending`);
 
-    cy.task('log', 'Upload link');
-    goTo('go-to-upload');
-    cy.get('stf-upload-option[icon="link"]').click();
-    cy.get('app-create-link pa-input input').type('https://nuclia.com/contact/');
-    cy.get('app-create-link button').contains('Add').click();
-    cy.get('.pa-toast-wrapper').should('contain', 'Upload successful');
-    cy.location('pathname').should('equal', `/at/${ACCOUNT.slug}/${emptyKb.zone}/${emptyKb.name}/resources/pending`);
+      cy.task('log', 'Upload link');
+      goTo('go-to-upload');
+      cy.get('stf-upload-option[icon="link"]').click();
+      cy.get('app-create-link pa-input input').type('https://nuclia.com/contact/');
+      cy.get('app-create-link button').contains('Add').click();
+      cy.get('.pa-toast-wrapper').should('contain', 'Upload successful');
+      cy.location('pathname').should('equal', `/at/${ACCOUNT.slug}/${zone.emptyKb.zone}/${zone.emptyKb.name}/resources/pending`);
 
-    checkResourceWasAdded(endpoint, 'nuclia-logo.png');
-    checkResourceWasAdded(endpoint, 'https://nuclia.com/contact/');
+      checkResourceWasAdded(endpoint, 'nuclia-logo.png');
+      checkResourceWasAdded(endpoint, 'https://nuclia.com/contact/');
+    });
   });
 });

--- a/cypress/e2e/1-basic/manage-content.cy.js
+++ b/cypress/e2e/1-basic/manage-content.cy.js
@@ -1,6 +1,6 @@
 /// <reference types="cypress" />
 
-import { ACCOUNT, ACCOUNT_STAGE, getAuthHeader, goTo } from '../../support/common';
+import { ACCOUNT, getAuthHeader, goTo } from '../../support/common';
 
 function checkResourceWasAdded(endpoint, resourceTitle) {
   cy.request({
@@ -17,7 +17,7 @@ function checkResourceWasAdded(endpoint, resourceTitle) {
 describe('Manage content', () => {
   const authHeader = getAuthHeader();
 
-  ACCOUNT_STAGE.availableZones.forEach((zone) => {
+  ACCOUNT.availableZones.forEach((zone) => {
     const endpoint = `https://${zone.slug}.${ACCOUNT.domain}/api/v1/kb/${zone.emptyKb.id}`;
 
     before(() => {

--- a/cypress/e2e/1-basic/manage-content.cy.js
+++ b/cypress/e2e/1-basic/manage-content.cy.js
@@ -1,6 +1,6 @@
 /// <reference types="cypress" />
 
-import { emptyKb, getAuthHeader, goTo } from '../../support/common';
+import { ACCOUNT, emptyKb, getAuthHeader, goTo, ZONES } from '../../support/common';
 
 function checkResourceWasAdded(endpoint, resourceTitle) {
   cy.request({
@@ -15,7 +15,7 @@ function checkResourceWasAdded(endpoint, resourceTitle) {
 }
 
 describe('Manage content', () => {
-  const endpoint = `https://europe-1.stashify.cloud/api/v1/kb/${emptyKb.id}`;
+  const endpoint = `https://${ZONES['europe']}.${ACCOUNT.domain}/api/v1/kb/${emptyKb.id}`;
   const authHeader = getAuthHeader();
 
   before(() => {
@@ -86,7 +86,7 @@ describe('Manage content', () => {
     cy.get('.status pa-icon[name="check"]', { timeout: 10000 }).should('exist');
     cy.get('app-upload-progress button[aria-label="Close"]').click();
     cy.get('.pa-toast-wrapper').should('contain', 'Upload successful');
-    cy.location('pathname').should('equal', `/at/testing/europe-1/${emptyKb.name}/resources/pending`);
+    cy.location('pathname').should('equal', `/at/${ACCOUNT.slug}/${emptyKb.zone}/${emptyKb.name}/resources/pending`);
 
     cy.task('log', 'Upload link');
     goTo('go-to-upload');
@@ -94,7 +94,7 @@ describe('Manage content', () => {
     cy.get('app-create-link pa-input input').type('https://nuclia.com/contact/');
     cy.get('app-create-link button').contains('Add').click();
     cy.get('.pa-toast-wrapper').should('contain', 'Upload successful');
-    cy.location('pathname').should('equal', `/at/testing/europe-1/${emptyKb.name}/resources/pending`);
+    cy.location('pathname').should('equal', `/at/${ACCOUNT.slug}/${emptyKb.zone}/${emptyKb.name}/resources/pending`);
 
     checkResourceWasAdded(endpoint, 'nuclia-logo.png');
     checkResourceWasAdded(endpoint, 'https://nuclia.com/contact/');

--- a/cypress/e2e/1-basic/resources.cy.js
+++ b/cypress/e2e/1-basic/resources.cy.js
@@ -1,6 +1,6 @@
 /// <reference types="cypress" />
 
-import { closeViewer, getAuthHeader, goTo, onlyPermanentKb, permanentKb } from '../../support/common';
+import { ACCOUNT, closeViewer, getAuthHeader, goTo, onlyPermanentKb, permanentKb, ZONES } from '../../support/common';
 import {
   expectedResourceTitle,
   firstQuery,
@@ -17,7 +17,7 @@ describe('Resources', () => {
   before(() => {
     onlyPermanentKb();
 
-    const endpoint = `https://europe-1.stashify.cloud/api/v1/kb/${permanentKb.id}`;
+    const endpoint = `https://${ZONES['europe']}.${ACCOUNT.domain}/api/v1/kb/${permanentKb.id}`;
     const authHeader = getAuthHeader();
 
     // keep only permanent labels on resources

--- a/cypress/e2e/1-basic/resources.cy.js
+++ b/cypress/e2e/1-basic/resources.cy.js
@@ -1,6 +1,6 @@
 /// <reference types="cypress" />
 
-import { ACCOUNT, closeViewer, getAuthHeader, goTo, onlyPermanentKb, permanentKb, ZONES } from '../../support/common';
+import { ACCOUNT, closeViewer, getAuthHeader, goTo, onlyPermanentKb, ZONES } from '../../support/common';
 import {
   expectedResourceTitle,
   firstQuery,
@@ -17,7 +17,7 @@ describe('Resources', () => {
   before(() => {
     onlyPermanentKb();
 
-    const endpoint = `https://${ZONES['europe']}.${ACCOUNT.domain}/api/v1/kb/${permanentKb.id}`;
+    const endpoint = `https://${ZONES['europe']}.${ACCOUNT.domain}/api/v1/kb/${ACCOUNT.permanentKb.id}`;
     const authHeader = getAuthHeader();
 
     // keep only permanent labels on resources

--- a/cypress/e2e/1-basic/resources.cy.js
+++ b/cypress/e2e/1-basic/resources.cy.js
@@ -70,13 +70,13 @@ describe('Resources', () => {
       });
 
       it('should display status', () => {
-        cy.login();
+        cy.login(zone);
         cy.get('.kb-metrics .title-m:first-of-type').should('contain', '2');
       });
 
       describe('Resources list', () => {
         beforeEach(() => {
-          cy.login();
+          cy.login(zone);
           goTo('go-to-resources');
         });
 
@@ -101,7 +101,7 @@ describe('Resources', () => {
 
       describe('Label sets', () => {
         beforeEach(() => {
-          cy.login();
+          cy.login(zone);
         });
 
         it('should list existing label set', () => {
@@ -133,7 +133,7 @@ describe('Resources', () => {
 
       describe('Search', () => {
         beforeEach(() => {
-          cy.login();
+          cy.login(zone);
           goTo('go-to-search');
         });
 

--- a/cypress/e2e/1-basic/resources.cy.js
+++ b/cypress/e2e/1-basic/resources.cy.js
@@ -1,6 +1,6 @@
 /// <reference types="cypress" />
 
-import { ACCOUNT, closeViewer, getAuthHeader, goTo, onlyPermanentKb, ZONES } from '../../support/common';
+import { ACCOUNT, closeViewer, getAuthHeader, goTo, onlyPermanentKb } from '../../support/common';
 import {
   expectedResourceTitle,
   firstQuery,
@@ -14,154 +14,159 @@ import {
 } from '../selectors/widget-selectors';
 
 describe('Resources', () => {
-  before(() => {
-    onlyPermanentKb();
+  ACCOUNT.availableZones.forEach((zone) => {
 
-    const endpoint = `https://${ZONES['europe']}.${ACCOUNT.domain}/api/v1/kb/${ACCOUNT.permanentKb.id}`;
-    const authHeader = getAuthHeader();
+    describe(`on ${zone.slug}`, () => {
+      before(() => {
+        onlyPermanentKb();
 
-    // keep only permanent labels on resources
-    cy.request({
-      method: 'GET',
-      url: `${endpoint}/resources`,
-      headers: authHeader
-    }).then(response => {
-      expect(response.status).to.eq(200);
-      response.body['resources'].forEach(resource => {
+        const endpoint = `https://${zone.slug}.${ACCOUNT.domain}/api/v1/kb/${zone.permanentKb.id}`;
+        const authHeader = getAuthHeader();
+
+        // keep only permanent labels on resources
         cy.request({
-          method: 'PATCH',
-          url: `${endpoint}/resource/${resource.id}`,
-          body: {
-            usermetadata: {
-              classifications: [{
-                labelset: 'dataset',
-                label: 'permanent',
-                cancelled_by_user: false
-              }], relations: []
-            }
-          },
+          method: 'GET',
+          url: `${endpoint}/resources`,
           headers: authHeader
-        }).then(patchResponse => expect(patchResponse.status).to.eq(200));
-      });
-    });
-
-    // clean up labelsets
-    cy.request({
-      method: 'GET',
-      url: `${endpoint}/labelsets`,
-      headers: authHeader
-    }).then(response => {
-      expect(response.status).to.eq(200);
-      const labelsets = Object.keys(response.body['labelsets']);
-      if (labelsets.length > 1) {
-        cy.task('log', `Delete ${labelsets.length - 1} label sets from previous tests`);
-        labelsets.filter(labelset => labelset !== 'dataset').forEach(labelset => {
-          cy.request({
-            method: 'DELETE',
-            url: `${endpoint}/labelset/${labelset}`,
-            headers: authHeader
-          }).then(deleteResponse => expect(deleteResponse.status).to.eq(200));
+        }).then(response => {
+          expect(response.status).to.eq(200);
+          response.body['resources'].forEach(resource => {
+            cy.request({
+              method: 'PATCH',
+              url: `${endpoint}/resource/${resource.id}`,
+              body: {
+                usermetadata: {
+                  classifications: [{
+                    labelset: 'dataset',
+                    label: 'permanent',
+                    cancelled_by_user: false
+                  }], relations: []
+                }
+              },
+              headers: authHeader
+            }).then(patchResponse => expect(patchResponse.status).to.eq(200));
+          });
         });
-      }
-    });
-  });
 
-  it('should display status', () => {
-    cy.login();
-    cy.get('.kb-metrics .title-m:first-of-type').should('contain', '2');
-  });
+        // clean up labelsets
+        cy.request({
+          method: 'GET',
+          url: `${endpoint}/labelsets`,
+          headers: authHeader
+        }).then(response => {
+          expect(response.status).to.eq(200);
+          const labelsets = Object.keys(response.body['labelsets']);
+          if (labelsets.length > 1) {
+            cy.task('log', `Delete ${labelsets.length - 1} label sets from previous tests`);
+            labelsets.filter(labelset => labelset !== 'dataset').forEach(labelset => {
+              cy.request({
+                method: 'DELETE',
+                url: `${endpoint}/labelset/${labelset}`,
+                headers: authHeader
+              }).then(deleteResponse => expect(deleteResponse.status).to.eq(200));
+            });
+          }
+        });
+      });
 
-  describe('Resources list', () => {
-    beforeEach(() => {
-      cy.login();
-      goTo('go-to-resources');
-    });
+      it('should display status', () => {
+        cy.login();
+        cy.get('.kb-metrics .title-m:first-of-type').should('contain', '2');
+      });
 
-    it('should list existing resources', () => {
-      cy.get('.resource-list pa-table-row').should('have.length', 2);
-    });
+      describe('Resources list', () => {
+        beforeEach(() => {
+          cy.login();
+          goTo('go-to-resources');
+        });
 
-    it('should allow to preview', () => {
-      cy.contains('Lamarr Lesson plan.pdf').click();
-      cy.get('.edit-resource > header').should('contain', 'Lamarr Lesson plan.pdf');
-      cy.get('.edit-resource .main-container .paragraph-container').should('contain', 'Lamarr Lesson plan.pdf');
-      cy.get('.edit-resource nav li:not(.active):first').click()
-      cy.get('.edit-resource .main-container').should('contain', 'Hedy Lamarr, An Inventive Mind');
-    });
+        it('should list existing resources', () => {
+          cy.get('.resource-list pa-table-row').should('have.length', 2);
+        });
 
-    it('should show labels on resources', () => {
-      cy.get('[data-cy="visible-columns-dropdown"]').click();
-      cy.get('pa-checkbox').contains('Labels').click();
-      cy.get('pa-chip-closeable').should('contain', 'permanent');
-    });
-  });
+        it('should allow to preview', () => {
+          cy.contains('Lamarr Lesson plan.pdf').click();
+          cy.get('.edit-resource > header').should('contain', 'Lamarr Lesson plan.pdf');
+          cy.get('.edit-resource .main-container .paragraph-container').should('contain', 'Lamarr Lesson plan.pdf');
+          cy.get('.edit-resource nav li:not(.active):first').click()
+          cy.get('.edit-resource .main-container').should('contain', 'Hedy Lamarr, An Inventive Mind');
+        });
 
-  describe('Label sets', () => {
-    beforeEach(() => {
-      cy.login();
-    });
+        it('should show labels on resources', () => {
+          cy.get('[data-cy="visible-columns-dropdown"]').click();
+          cy.get('pa-checkbox').contains('Labels').click();
+          cy.get('pa-chip-closeable').should('contain', 'permanent');
+        });
+      });
 
-    it('should list existing label set', () => {
-      goTo('go-to-advanced');
-      goTo('go-to-classification');
-      cy.get('[data-cy="resource-label-sets"]').contains('dataset').click();
-      cy.get('[data-cy="label-list-input"] textarea').should('have.value', 'permanent');
-    });
+      describe('Label sets', () => {
+        beforeEach(() => {
+          cy.login();
+        });
 
-    it('should create a label set', () => {
-      const labelset = 'Heroes';
-      const label1 = 'Catwoman';
-      const label2 = 'Poison Ivy';
-      goTo('go-to-advanced');
-      goTo('go-to-classification');
-      cy.get('[data-cy="add-label-set"]').click();
-      cy.get('[data-cy="label-set-title-input"]').type(labelset);
-      cy.get('.pa-toggle').contains('Resources').click();
-      cy.get('[data-cy="label-list-input"]').type(`${label1}`);
-      cy.get('[data-cy="grid-view"]').click();
-      cy.get('[data-cy="label-item-input"]').type(`${label2}{enter}`);
-      cy.get('[data-cy="label-grid"]').find('nsi-label').should('have.length', 2);
-      cy.get('[data-cy="list-view"]').click();
-      cy.get('[data-cy="label-list-input"] textarea').should('have.value', `${label1}, ${label2}`)
-      cy.get('[data-cy="save-label-set"]').click();
-      cy.get('[data-cy="resource-label-sets"]').should('contain', 'Heroes');
-    });
-  });
+        it('should list existing label set', () => {
+          goTo('go-to-advanced');
+          goTo('go-to-classification');
+          cy.get('[data-cy="resource-label-sets"]').contains('dataset').click();
+          cy.get('[data-cy="label-list-input"] textarea').should('have.value', 'permanent');
+        });
 
-  describe('Search', () => {
-    beforeEach(() => {
-      cy.login();
-      goTo('go-to-search');
-    });
+        it('should create a label set', () => {
+          const labelset = 'Heroes';
+          const label1 = 'Catwoman';
+          const label2 = 'Poison Ivy';
+          goTo('go-to-advanced');
+          goTo('go-to-classification');
+          cy.get('[data-cy="add-label-set"]').click();
+          cy.get('[data-cy="label-set-title-input"]').type(labelset);
+          cy.get('.pa-toggle').contains('Resources').click();
+          cy.get('[data-cy="label-list-input"]').type(`${label1}`);
+          cy.get('[data-cy="grid-view"]').click();
+          cy.get('[data-cy="label-item-input"]').type(`${label2}{enter}`);
+          cy.get('[data-cy="label-grid"]').find('nsi-label').should('have.length', 2);
+          cy.get('[data-cy="list-view"]').click();
+          cy.get('[data-cy="label-list-input"] textarea').should('have.value', `${label1}, ${label2}`)
+          cy.get('[data-cy="save-label-set"]').click();
+          cy.get('[data-cy="resource-label-sets"]').should('contain', 'Heroes');
+        });
+      });
 
-    it('should show suggestions and open preview from it', () => {
-      cy.get(nucliaSearchBarSelector).shadow().find('.sw-search-input input').type('Lamarr');
-      cy.get(nucliaSearchBarSelector).shadow().find(suggestionResultSelector).should('have.length', 2);
-      cy.get(nucliaSearchBarSelector).shadow().find(`${suggestionResultSelector}:first-child`).click();
-      cy.get(nucliaSearchResultsSelector).shadow().find('.sw-viewer .header-title').should('contain', 'Lamarr Lesson plan.pdf');
-      closeViewer();
-    });
+      describe('Search', () => {
+        beforeEach(() => {
+          cy.login();
+          goTo('go-to-search');
+        });
 
-    it('should display results', () => {
-      cy.get(nucliaSearchBarSelector).shadow().find(searchBarInputSelector).type(`${firstQuery}\n`, { force: true });
-      cy.get(nucliaSearchResultsSelector)
-        .shadow()
-        .find(`${searchResultContainerSelector} ${searchResultTitle}`)
-        .should('have.length', 1);
-      cy.get(nucliaSearchResultsSelector)
-        .shadow()
-        .find(`${searchResultContainerSelector} ${searchResultTitle}`)
-        .should('contain', expectedResourceTitle);
-      cy.get(nucliaSearchResultsSelector)
-        .shadow()
-        .find(`${searchResultContainerSelector} ${searchResultTitle}`)
-        .contains(expectedResourceTitle)
-        .click();
-      cy.get(nucliaSearchResultsSelector)
-        .shadow()
-        .find(`${viewerSelector} .header-title .title-m`)
-        .should('contain', expectedResourceTitle);
-      closeViewer();
+        it('should show suggestions and open preview from it', () => {
+          cy.get(nucliaSearchBarSelector).shadow().find('.sw-search-input input').type('Lamarr');
+          cy.get(nucliaSearchBarSelector).shadow().find(suggestionResultSelector).should('have.length', 2);
+          cy.get(nucliaSearchBarSelector).shadow().find(`${suggestionResultSelector}:first-child`).click();
+          cy.get(nucliaSearchResultsSelector).shadow().find('.sw-viewer .header-title').should('contain', 'Lamarr Lesson plan.pdf');
+          closeViewer();
+        });
+
+        it('should display results', () => {
+          cy.get(nucliaSearchBarSelector).shadow().find(searchBarInputSelector).type(`${firstQuery}\n`, { force: true });
+          cy.get(nucliaSearchResultsSelector)
+            .shadow()
+            .find(`${searchResultContainerSelector} ${searchResultTitle}`)
+            .should('have.length', 1);
+          cy.get(nucliaSearchResultsSelector)
+            .shadow()
+            .find(`${searchResultContainerSelector} ${searchResultTitle}`)
+            .should('contain', expectedResourceTitle);
+          cy.get(nucliaSearchResultsSelector)
+            .shadow()
+            .find(`${searchResultContainerSelector} ${searchResultTitle}`)
+            .contains(expectedResourceTitle)
+            .click();
+          cy.get(nucliaSearchResultsSelector)
+            .shadow()
+            .find(`${viewerSelector} .header-title .title-m`)
+            .should('contain', expectedResourceTitle);
+          closeViewer();
+        });
+      });
     });
   });
 });

--- a/cypress/e2e/2-nua/create-key-with-dashboard.cy.js
+++ b/cypress/e2e/2-nua/create-key-with-dashboard.cy.js
@@ -14,7 +14,7 @@ describe('Create NUA key with the dashboard', () => {
         expect(response.status).to.eq(200);
         const clients = response.body['clients'] || [];
         if (clients.length > 1) {
-          clients.filter((client) => !client['title'].include('e2e')).forEach(client => {
+          clients.filter((client) => !client['title'].includes('e2e')).forEach(client => {
             cy.request({
               method: 'DELETE',
               url: `https://${zone.slug}.${ACCOUNT.domain}/api/v1/account/${ACCOUNT.id}/nua_client/${client.client_id}`,

--- a/cypress/e2e/2-nua/create-key-with-dashboard.cy.js
+++ b/cypress/e2e/2-nua/create-key-with-dashboard.cy.js
@@ -3,9 +3,9 @@
 import { ACCOUNT, getAuthHeader, goTo, goToManageAccount } from '../../support/common';
 
 describe('Create NUA key with the dashboard', () => {
-  before(() => {
-    const authHeader = getAuthHeader();
-    ACCOUNT.availableZones.forEach((zone) => {
+  const authHeader = getAuthHeader();
+  ACCOUNT.availableZones.forEach((zone) => {
+    before(() => {
       cy.request({
         method: 'GET',
         url: `https://${zone.slug}.${ACCOUNT.domain}/api/v1/account/${ACCOUNT.id}/nua_clients`,
@@ -24,24 +24,24 @@ describe('Create NUA key with the dashboard', () => {
         }
       });
     });
-  });
 
-  beforeEach(() => cy.login());
+    beforeEach(() => cy.login(zone));
 
-  it('creates and deletes key', () => {
-    goToManageAccount();
-    goTo('go-to-nua-keys');
-    // Create NUA key
-    cy.get('[data-cy="open-create-nua-key-dialog"]').click();
-    cy.get('pa-modal-advanced').should('be.visible');
-    cy.get('pa-modal-advanced input[name="title"]').should('be.visible').type('A new key');
-    cy.get('pa-modal-advanced').get('[data-cy="save-nua-client"]').click();
-    cy.get('pa-modal-dialog').get('[data-cy="copy-token"]').click();
-    cy.get('pa-modal-dialog').get('[data-cy="close-token-dialog"]').click();
+    it('creates and deletes key', () => {
+      goToManageAccount();
+      goTo('go-to-nua-keys');
+      // Create NUA key
+      cy.get('[data-cy="open-create-nua-key-dialog"]').click();
+      cy.get('pa-modal-advanced').should('be.visible');
+      cy.get('pa-modal-advanced input[name="title"]').should('be.visible').type('A new key');
+      cy.get('pa-modal-advanced').get('[data-cy="save-nua-client"]').click();
+      cy.get('pa-modal-dialog').get('[data-cy="copy-token"]').click();
+      cy.get('pa-modal-dialog').get('[data-cy="close-token-dialog"]').click();
 
-    // Delete NUA key
-    cy.get('.page-spacing .client-row').contains('A new key');
-    cy.get(`[data-cy="A new key-delete"]`).click();
-    cy.get('[qa="confirmation-dialog-confirm-button"]').click();
+      // Delete NUA key
+      cy.get('.page-spacing .client-row').contains('A new key');
+      cy.get(`[data-cy="A new key-delete"]`).click();
+      cy.get('[qa="confirmation-dialog-confirm-button"]').click();
+    });
   });
 });

--- a/cypress/e2e/2-nua/create-key-with-dashboard.cy.js
+++ b/cypress/e2e/2-nua/create-key-with-dashboard.cy.js
@@ -1,27 +1,28 @@
 /// <reference types="cypress" />
 
-import { ACCOUNT, getAuthHeader, goTo, goToManageAccount, user, ZONES } from '../../support/common';
+import { ACCOUNT, getAuthHeader, goTo, goToManageAccount } from '../../support/common';
 
 describe('Create NUA key with the dashboard', () => {
   before(() => {
     const authHeader = getAuthHeader();
-    // https://stashify.cloud/api/v1/account/testing/nua_clients
-    cy.request({
-      method: 'GET',
-      url: `https://${ZONES['europe']}.${ACCOUNT.domain}/api/v1/account/${ACCOUNT.id}/nua_clients`,
-      headers: authHeader
-    }).then(response => {
-      expect(response.status).to.eq(200);
-      const clients = response.body['clients'] || [];
-      if (clients.length > 1) {
-        clients.filter((client) => client['title'] !== 'e2e').forEach(client => {
-          cy.request({
-            method: 'DELETE',
-            url: `https://${ZONES['europe']}.${ACCOUNT.domain}/api/v1/account/${ACCOUNT.id}/nua_client/${client.client_id}`,
-            headers: authHeader
-          }).then(patchResponse => expect(patchResponse.status).to.eq(204));
-        });
-      }
+    ACCOUNT.availableZones.forEach((zone) => {
+      cy.request({
+        method: 'GET',
+        url: `https://${zone.slug}.${ACCOUNT.domain}/api/v1/account/${ACCOUNT.id}/nua_clients`,
+        headers: authHeader
+      }).then(response => {
+        expect(response.status).to.eq(200);
+        const clients = response.body['clients'] || [];
+        if (clients.length > 1) {
+          clients.filter((client) => !client['title'].include('e2e')).forEach(client => {
+            cy.request({
+              method: 'DELETE',
+              url: `https://${zone.slug}.${ACCOUNT.domain}/api/v1/account/${ACCOUNT.id}/nua_client/${client.client_id}`,
+              headers: authHeader
+            }).then(patchResponse => expect(patchResponse.status).to.eq(204));
+          });
+        }
+      });
     });
   });
 

--- a/cypress/e2e/2-nua/create-key-with-dashboard.cy.js
+++ b/cypress/e2e/2-nua/create-key-with-dashboard.cy.js
@@ -1,6 +1,6 @@
 /// <reference types="cypress" />
 
-import { ACCOUNT, getAuthHeader, goTo, goToManageAccount, user } from '../../support/common';
+import { ACCOUNT, getAuthHeader, goTo, goToManageAccount, user, ZONES } from '../../support/common';
 
 describe('Create NUA key with the dashboard', () => {
   before(() => {
@@ -8,7 +8,7 @@ describe('Create NUA key with the dashboard', () => {
     // https://stashify.cloud/api/v1/account/testing/nua_clients
     cy.request({
       method: 'GET',
-      url: `https://europe-1.stashify.cloud/api/v1/account/${ACCOUNT.id}/nua_clients`,
+      url: `https://${ZONES['europe']}.${ACCOUNT.domain}/api/v1/account/${ACCOUNT.id}/nua_clients`,
       headers: authHeader
     }).then(response => {
       expect(response.status).to.eq(200);
@@ -17,7 +17,7 @@ describe('Create NUA key with the dashboard', () => {
         clients.filter((client) => client['title'] !== 'e2e').forEach(client => {
           cy.request({
             method: 'DELETE',
-            url: `https://europe-1.stashify.cloud/api/v1/account/${ACCOUNT.id}/nua_client/${client.client_id}`,
+            url: `https://${ZONES['europe']}.${ACCOUNT.domain}/api/v1/account/${ACCOUNT.id}/nua_client/${client.client_id}`,
             headers: authHeader
           }).then(patchResponse => expect(patchResponse.status).to.eq(204));
         });

--- a/cypress/e2e/2-nua/push-to-api.cy.js
+++ b/cypress/e2e/2-nua/push-to-api.cy.js
@@ -1,36 +1,42 @@
 /// <reference types="cypress" />
+import { ACCOUNT } from '../../support/common';
+
 describe('Push file', () => {
   it('pushes a file to NUA queue', () => {
-    cy.fixture('nuclia-logo.png')
-      .then((file) =>
-        cy.request({
-          method: 'POST',
-          url: `https://europe-1.stashify.cloud/api/v1/processing/upload`,
-          headers: { 'x-stf-nuakey': `Bearer ${Cypress.env('NUA_KEY')}`, md5: 'fa7bfc3072bf547b3d3f5c75050adadf' },
-          body: file
-        })
-      )
-      .then((resp) => {
-        expect(resp.status).to.eq(200);
-        return cy.request({
-          method: 'POST',
-          json: true,
-          url: `https://europe-1.stashify.cloud/api/v1/processing/push`,
-          headers: { 'x-stf-nuakey': `Bearer ${Cypress.env('NUA_KEY')}` },
-          body: {
-            filefield: { 'nuclia-logo.png': resp.body }
-          }
+    ACCOUNT.availableZones.forEach((zone) => {
+      cy.fixture('nuclia-logo.png')
+        .then((file) =>
+          cy.request({
+            method: 'POST',
+            url: `https://${zone.slug}.${ACCOUNT.domain}/api/v1/processing/upload`,
+            headers: { 'x-stf-nuakey': `Bearer ${zone.nuaKey}`, md5: 'fa7bfc3072bf547b3d3f5c75050adadf' },
+            body: file
+          })
+        )
+        .then((resp) => {
+          expect(resp.status).to.eq(200);
+          return cy.request({
+            method: 'POST',
+            json: true,
+            url: `https://${zone.slug}.${ACCOUNT.domain}/api/v1/processing/push`,
+            headers: { 'x-stf-nuakey': `Bearer ${zone.nuaKey}` },
+            body: {
+              filefield: { 'nuclia-logo.png': resp.body }
+            }
+          });
         });
-      });
+    })
   });
 
   it('pulls results', () => {
-    cy
-      .request({
-        method: 'GET',
-        url: `https://europe-1.stashify.cloud/api/v1/processing/pull`,
-        headers: { 'x-stf-nuakey': `Bearer ${Cypress.env('NUA_KEY')}` }
-      })
-      .then((res) => expect(res.status).to.eq(200));
+    ACCOUNT.availableZones.forEach((zone) => {
+      cy
+        .request({
+          method: 'GET',
+          url: `https://${zone.slug}.${ACCOUNT.domain}/api/v1/processing/pull`,
+          headers: { 'x-stf-nuakey': `Bearer ${zone.nuaKey}` }
+        })
+        .then((res) => expect(res.status).to.eq(200));
+    });
   });
 });

--- a/cypress/e2e/3-widget/ask.cy.js
+++ b/cypress/e2e/3-widget/ask.cy.js
@@ -15,61 +15,67 @@ import {
   secondQuery,
   answerSourceTitleSelector, answerCitationSelector
 } from '../selectors/widget-selectors';
+import { ACCOUNT } from '../../support/common';
 
 describe('Ask', () => {
-  beforeEach(() => {
-    cy.visit('https://nuclia.github.io/frontend/e2e/ask.html');
-  });
 
-  it('should display initial answer and allow to chat with your docs', () => {
-    cy.get(nucliaSearchBarSelector).shadow().find(searchBarInputSelector).click();
-    cy.get(nucliaSearchBarSelector).shadow().find(searchBarInputSelector).type(`${firstQuery}\n`, { force: true });
-    cy.get(nucliaSearchResultsSelector)
-      .shadow()
-      .find(`${initialAnswerSelector} ${answerContainerSelector}`, {timeout: 6000})
-      .should('exist');
+  ACCOUNT.availableZones.forEach((zone) => {
+    describe(`on ${zone.slug}`, () => {
+      beforeEach(() => {
+        cy.visit(zone.askUrl);
+      });
 
-    // chat with your doc
-    cy.get(nucliaSearchResultsSelector).shadow().find(`${initialAnswerSelector} ${chatWithYourDocsSelector}`).click();
-    cy.get(nucliaSearchResultsSelector)
-      .shadow()
-      .find(`${chatContainerSelector} ${chatQuestionSelector}`)
-      .should('contain', firstQuery);
-    cy.get(nucliaSearchResultsSelector)
-      .shadow()
-      .find(`${chatContainerSelector} ${answerContainerSelector}`)
-      .should('have.length.at.least', 1);
+      it('should display initial answer and allow to chat with your docs', () => {
+        cy.get(nucliaSearchBarSelector).shadow().find(searchBarInputSelector).click();
+        cy.get(nucliaSearchBarSelector).shadow().find(searchBarInputSelector).type(`${firstQuery}\n`, { force: true });
+        cy.get(nucliaSearchResultsSelector)
+          .shadow()
+          .find(`${initialAnswerSelector} ${answerContainerSelector}`, {timeout: 6000})
+          .should('exist');
 
-    cy.get(nucliaSearchResultsSelector)
-      .shadow()
-      .find(`${chatContainerSelector} ${chatInputSelector}`)
-      .type(`${secondQuery}\n`);
-    cy.get(nucliaSearchResultsSelector)
-      .shadow()
-      .find(`${chatContainerSelector} ${chatQuestionSelector}`)
-      .should('have.length.at.least', 1)
-      .and('contain', secondQuery);
-    cy.get(nucliaSearchResultsSelector)
-      .shadow()
-      .find(`${chatContainerSelector} ${answerContainerSelector}`)
-      .should('have.length.at.least', 1);
-  });
+        // chat with your doc
+        cy.get(nucliaSearchResultsSelector).shadow().find(`${initialAnswerSelector} ${chatWithYourDocsSelector}`).click();
+        cy.get(nucliaSearchResultsSelector)
+          .shadow()
+          .find(`${chatContainerSelector} ${chatQuestionSelector}`)
+          .should('contain', firstQuery);
+        cy.get(nucliaSearchResultsSelector)
+          .shadow()
+          .find(`${chatContainerSelector} ${answerContainerSelector}`)
+          .should('have.length.at.least', 1);
 
-  // This test is disabled because returned sources are not deterministic at the moment
-  it('should display citations and search results that have been used to generate the answer', () => {
-    cy.get(nucliaSearchBarSelector).shadow().find(searchBarInputSelector).click();
-    cy.get(nucliaSearchBarSelector).shadow().find(searchBarInputSelector).type(`${secondQuery}\n`, { force: true });
-    cy.get(nucliaSearchResultsSelector)
-      .shadow()
-      .find(`${initialAnswerSelector} ${answerContainerSelector}`, {timeout: 6000})
-      .should('exist');
-    cy.get(nucliaSearchResultsSelector)
-      .shadow()
-      .find(`${initialAnswerSelector} ${answerCitationSelector}`)
-      .should('contain', 1);
-    cy.get(nucliaSearchResultsSelector)
-      .shadow()
-      .find(`${initialAnswerSelector} ${answerSourceTitleSelector}`)
-      .should('contain', expectedResourceTitle);
+        cy.get(nucliaSearchResultsSelector)
+          .shadow()
+          .find(`${chatContainerSelector} ${chatInputSelector}`)
+          .type(`${secondQuery}\n`);
+        cy.get(nucliaSearchResultsSelector)
+          .shadow()
+          .find(`${chatContainerSelector} ${chatQuestionSelector}`)
+          .should('have.length.at.least', 1)
+          .and('contain', secondQuery);
+        cy.get(nucliaSearchResultsSelector)
+          .shadow()
+          .find(`${chatContainerSelector} ${answerContainerSelector}`)
+          .should('have.length.at.least', 1);
+      });
+
+      // This test is disabled because returned sources are not deterministic at the moment
+      it('should display citations and search results that have been used to generate the answer', () => {
+        cy.get(nucliaSearchBarSelector).shadow().find(searchBarInputSelector).click();
+        cy.get(nucliaSearchBarSelector).shadow().find(searchBarInputSelector).type(`${secondQuery}\n`, { force: true });
+        cy.get(nucliaSearchResultsSelector)
+          .shadow()
+          .find(`${initialAnswerSelector} ${answerContainerSelector}`, {timeout: 6000})
+          .should('exist');
+        cy.get(nucliaSearchResultsSelector)
+          .shadow()
+          .find(`${initialAnswerSelector} ${answerCitationSelector}`)
+          .should('contain', 1);
+        cy.get(nucliaSearchResultsSelector)
+          .shadow()
+          .find(`${initialAnswerSelector} ${answerSourceTitleSelector}`)
+          .should('contain', expectedResourceTitle);
+      });
+    });
   });
 });

--- a/cypress/e2e/3-widget/find.cy.js
+++ b/cypress/e2e/3-widget/find.cy.js
@@ -13,45 +13,50 @@ import {
   secondQuery,
   searchResultTitle,
 } from '../selectors/widget-selectors';
+import { ACCOUNT } from '../../support/common';
 
 describe('Find', () => {
-  beforeEach(() => {
-    cy.visit('https://nuclia.github.io/frontend/e2e/find.html');
-  });
+  ACCOUNT.availableZones.forEach((zone) => {
+    describe(`on ${zone.slug}`, () => {
+      beforeEach(() => {
+        cy.visit(zone.findUrl);
+      });
 
-  it('should display results, preview and allow to search paragraphs in the resource', () => {
-    cy.get(nucliaSearchBarSelector).shadow().find(searchBarInputSelector).type(`${firstQuery}\n`, { force: true });
-    cy.get(nucliaSearchResultsSelector)
-      .shadow()
-      .find(`${searchResultContainerSelector} ${searchResultTitle}`)
-      .should('contain', expectedResourceTitle);
-    cy.get(nucliaSearchResultsSelector)
-      .shadow()
-      .find(`${searchResultContainerSelector} ${searchResultLiSelector}`)
-      .should('have.length.at.least', 1);
+      it('should display results, preview and allow to search paragraphs in the resource', () => {
+        cy.get(nucliaSearchBarSelector).shadow().find(searchBarInputSelector).type(`${firstQuery}\n`, { force: true });
+        cy.get(nucliaSearchResultsSelector)
+          .shadow()
+          .find(`${searchResultContainerSelector} ${searchResultTitle}`)
+          .should('contain', expectedResourceTitle);
+        cy.get(nucliaSearchResultsSelector)
+          .shadow()
+          .find(`${searchResultContainerSelector} ${searchResultLiSelector}`)
+          .should('have.length.at.least', 1);
 
-    // should allow to preview in the resource
-    cy.get(nucliaSearchResultsSelector)
-      .shadow()
-      .find(`${searchResultContainerSelector} ${searchResultTitle}`)
-      .contains(expectedResourceTitle)
-      .click();
-    cy.get(nucliaSearchResultsSelector).shadow().find(viewerSelector).should('contain', expectedResourceTitle);
+        // should allow to preview in the resource
+        cy.get(nucliaSearchResultsSelector)
+          .shadow()
+          .find(`${searchResultContainerSelector} ${searchResultTitle}`)
+          .contains(expectedResourceTitle)
+          .click();
+        cy.get(nucliaSearchResultsSelector).shadow().find(viewerSelector).should('contain', expectedResourceTitle);
 
-    // should allow to search paragraphs in the resource
-    cy.get(nucliaSearchResultsSelector).shadow().find(`${viewerSelector} .side-panel-button`).click();
-    cy.get(nucliaSearchResultsSelector)
-      .shadow()
-      .find(`${viewerSelector} ${searchResultLiSelector}`)
-      .should('have.length.at.least', 1);
-    cy.get(nucliaSearchResultsSelector).shadow().find(`${viewerSelector} ${findInResourceInputSelector}`).click();
-    cy.get(nucliaSearchResultsSelector)
-      .shadow()
-      .find(`${viewerSelector} ${findInResourceInputSelector}`)
-      .type(`${secondQuery}\n`);
-    cy.get(nucliaSearchResultsSelector)
-      .shadow()
-      .find(`${viewerSelector} ${searchResultLiSelector}`)
-      .should('have.length.at.least', 1);
+        // should allow to search paragraphs in the resource
+        cy.get(nucliaSearchResultsSelector).shadow().find(`${viewerSelector} .side-panel-button`).click();
+        cy.get(nucliaSearchResultsSelector)
+          .shadow()
+          .find(`${viewerSelector} ${searchResultLiSelector}`)
+          .should('have.length.at.least', 1);
+        cy.get(nucliaSearchResultsSelector).shadow().find(`${viewerSelector} ${findInResourceInputSelector}`).click();
+        cy.get(nucliaSearchResultsSelector)
+          .shadow()
+          .find(`${viewerSelector} ${findInResourceInputSelector}`)
+          .type(`${secondQuery}\n`);
+        cy.get(nucliaSearchResultsSelector)
+          .shadow()
+          .find(`${viewerSelector} ${searchResultLiSelector}`)
+          .should('have.length.at.least', 1);
+      });
+    });
   });
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -9,7 +9,7 @@
 // ***********************************************
 
 
-function login(kbName = 'permanent') {
+function login(kbName) {
   cy.visit(`/`, {
     onBeforeLoad(win) {
       // Store auth tokens
@@ -22,7 +22,7 @@ function login(kbName = 'permanent') {
 }
 
 // -- This is a parent command --
-Cypress.Commands.add('login', () => login());
+Cypress.Commands.add('login', (zone) => login(zone.permanentKb.name));
 Cypress.Commands.add('loginToEmptyKb', (zone) => login(zone.emptyKb.name));
 
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -9,7 +9,6 @@
 // ***********************************************
 
 
-import { emptyKb } from './common';
 function login(kbName = 'permanent') {
   cy.visit(`/`, {
     onBeforeLoad(win) {
@@ -24,7 +23,7 @@ function login(kbName = 'permanent') {
 
 // -- This is a parent command --
 Cypress.Commands.add('login', () => login());
-Cypress.Commands.add('loginToEmptyKb', () => login(emptyKb.name));
+Cypress.Commands.add('loginToEmptyKb', (zone) => login(zone.emptyKb.name));
 
 
 // -- This is a child command --

--- a/cypress/support/common.js
+++ b/cypress/support/common.js
@@ -1,6 +1,6 @@
 import { closeButton, nucliaSearchResultsSelector, viewerSelector } from '../e2e/selectors/widget-selectors';
 
-export const ZONES = {
+const ZONES = {
   europe: 'europe-1',
   usa: 'aws-us-east-2-1'
 }

--- a/cypress/support/common.js
+++ b/cypress/support/common.js
@@ -28,7 +28,9 @@ export const ACCOUNT_STAGE = {
       slug: 'permanent-empty',
       id: '1efc5a33-bc5a-490c-8b47-b190beee212d',
       zone: ZONES['europe'],
-    }
+    },
+    askUrl: 'https://nuclia.github.io/frontend/e2e/ask.html',
+    findUrl: 'https://nuclia.github.io/frontend/e2e/find.html',
   }],
 };
 
@@ -50,7 +52,9 @@ export const ACCOUNT_PROD = {
       slug: 'permanent-empty',
       id: '6176242a-b15d-459b-b4b9-5740fc1fed72',
       zone: ZONES['europe'],
-    }
+    },
+    askUrl: 'https://nuclia.github.io/frontend/e2e/prod/ask-europe.html',
+    findUrl: 'https://nuclia.github.io/frontend/e2e/prod/find-europe.html'
   }, {
     slug: ZONES['usa'],
     nuaKey: `${Cypress.env('NUA_KEY_PROD_USA')}`,
@@ -65,7 +69,9 @@ export const ACCOUNT_PROD = {
       slug: 'permanent-empty-usa',
       id: '53861c47-20b2-4c6f-bd7a-3286ca5bec13',
       zone: ZONES['usa'],
-    }
+    },
+    askUrl: 'https://nuclia.github.io/frontend/e2e/prod/ask-usa.html',
+    findUrl: 'https://nuclia.github.io/frontend/e2e/prod/find-usa.html'
   }],
 };
 

--- a/cypress/support/common.js
+++ b/cypress/support/common.js
@@ -75,7 +75,7 @@ export const ACCOUNT_PROD = {
   }],
 };
 
-export const ACCOUNT = `${Cypress.env('CYPRESS_RUNNING_ENV')}` === 'prod' ? ACCOUNT_PROD : ACCOUNT_STAGE;
+export const ACCOUNT = `${Cypress.env('RUNNING_ENV')}` === 'prod' ? ACCOUNT_PROD : ACCOUNT_STAGE;
 
 export const user = {
   email: `${Cypress.env('USER_NAME')}`,

--- a/cypress/support/common.js
+++ b/cypress/support/common.js
@@ -1,23 +1,50 @@
 import { closeButton, nucliaSearchResultsSelector, viewerSelector } from '../e2e/selectors/widget-selectors';
 
+export const ZONES = {
+  europe: 'europe-1',
+  usa: 'aws-us-east-2-1'
+}
+
 export const STANDALONE_KB_NAME = `${Cypress.env('STANDALONE_KB_NAME')}`;
 export const STANDALONE_HEADER = {
   'X-NUCLIADB-ROLES': 'MANAGER',
 };
 
-export const ACCOUNT = {
+export const ACCOUNT_STAGE = {
   id: '23d9209a-34be-4648-8ef0-5b522f9976be',
   slug: 'testing',
+  domain: 'stashify.cloud',
+  availableZones: [{
+    slug: ZONES['europe'],
+    nuaKey: `${Cypress.env('NUA_KEY')}`
+  }],
 };
+export const ACCOUNT_PROD = {
+  id: '5cec111b-ea23-4b0c-a82a-d1a666dd1fd2',
+  slug: 'nuclia-testing',
+  domain: 'nuclia.cloud',
+  availableZones: [{
+    slug: ZONES['europe'],
+    nuaKey: `${Cypress.env('NUA_KEY_PROD_EUROPE')}`
+  }, {
+    slug: ZONES['usa'],
+    nuaKey: `${Cypress.env('NUA_KEY_PROD_USA')}`
+  }],
+};
+
+export const ACCOUNT = Cypress.env('CYPRESS_RUNNING_ENV') === 'prod' ? ACCOUNT_PROD : ACCOUNT_STAGE;
 
 export const permanentKb = {
   name: 'permanent',
-  id: '096d9070-f7be-40c8-a24c-19c89072e3ff',
+  slug: 'permanent',
+  id: Cypress.env('CYPRESS_RUNNING_ENV') === 'prod' ? 'f639477f-dd3d-4509-b278-7ab20ff73bd1' : '096d9070-f7be-40c8-a24c-19c89072e3ff',
+  zone: ZONES['europe'],
 };
-
 export const emptyKb = {
   name: 'permanent-empty',
-  id: '1efc5a33-bc5a-490c-8b47-b190beee212d',
+  slug: 'permanent-empty',
+  id: Cypress.env('CYPRESS_RUNNING_ENV') === 'prod' ? '6176242a-b15d-459b-b4b9-5740fc1fed72' : '1efc5a33-bc5a-490c-8b47-b190beee212d',
+  zone: ZONES['europe'],
 };
 
 export const user = {
@@ -33,11 +60,15 @@ export function getAuthHeader(synchronous = true) {
   return headers;
 }
 
-export function onlyPermanentKb() {
+/**
+ * Keep only permanent KB on specified zone and account.
+ * @param zone europe | usa
+ */
+export function onlyPermanentKb(zone = 'europe') {
   const authHeader = { Authorization: `Bearer ${Cypress.env('BEARER_TOKEN')}` };
   cy.request({
     method: 'GET',
-    url: `https://europe-1.stashify.cloud/api/v1/account/${ACCOUNT.id}/kbs`,
+    url: `https://${ZONES[zone]}.${ACCOUNT.domain}/api/v1/account/${ACCOUNT.id}/kbs`,
     headers: authHeader,
   }).then((response) => {
     expect(response.status).to.eq(200);
@@ -47,7 +78,7 @@ export function onlyPermanentKb() {
         if (!kb.slug.includes('permanent')) {
           cy.request({
             method: 'DELETE',
-            url: `https://stashify.cloud/api/v1/account/testing/kb/${kb.slug}`,
+            url: `https://${ACCOUNT.domain}/api/v1/account/${ACCOUNT.slug}/kb/${kb.slug}`,
             headers: authHeader,
           }).then((deleteResponse) => {
             expect(deleteResponse.status).to.eq(204);

--- a/cypress/support/common.js
+++ b/cypress/support/common.js
@@ -16,36 +16,60 @@ export const ACCOUNT_STAGE = {
   domain: 'stashify.cloud',
   availableZones: [{
     slug: ZONES['europe'],
-    nuaKey: `${Cypress.env('NUA_KEY')}`
+    nuaKey: `${Cypress.env('NUA_KEY')}`,
+    permanentKb: {
+      name: 'permanent',
+      slug: 'permanent',
+      id: '096d9070-f7be-40c8-a24c-19c89072e3ff',
+      zone: ZONES['europe'],
+    },
+    emptyKb: {
+      name: 'permanent-empty',
+      slug: 'permanent-empty',
+      id: '1efc5a33-bc5a-490c-8b47-b190beee212d',
+      zone: ZONES['europe'],
+    }
   }],
 };
+
 export const ACCOUNT_PROD = {
   id: '5cec111b-ea23-4b0c-a82a-d1a666dd1fd2',
   slug: 'nuclia-testing',
   domain: 'nuclia.cloud',
   availableZones: [{
     slug: ZONES['europe'],
-    nuaKey: `${Cypress.env('NUA_KEY_PROD_EUROPE')}`
+    nuaKey: `${Cypress.env('NUA_KEY_PROD_EUROPE')}`,
+    permanentKb: {
+      name: 'permanent',
+      slug: 'permanent',
+      id: 'f639477f-dd3d-4509-b278-7ab20ff73bd1',
+      zone: ZONES['europe'],
+    },
+    emptyKb: {
+      name: 'permanent-empty',
+      slug: 'permanent-empty',
+      id: '6176242a-b15d-459b-b4b9-5740fc1fed72',
+      zone: ZONES['europe'],
+    }
   }, {
     slug: ZONES['usa'],
-    nuaKey: `${Cypress.env('NUA_KEY_PROD_USA')}`
+    nuaKey: `${Cypress.env('NUA_KEY_PROD_USA')}`,
+    permanentKb: {
+      name: 'permanent USA',
+      slug: 'permanent-usa',
+      id: 'b6805475-88da-47a0-a8fb-a044919f692e',
+      zone: ZONES['usa'],
+    },
+    emptyKb: {
+      name: 'permanent-empty USA',
+      slug: 'permanent-empty-usa',
+      id: '53861c47-20b2-4c6f-bd7a-3286ca5bec13',
+      zone: ZONES['usa'],
+    }
   }],
 };
 
-export const ACCOUNT = Cypress.env('CYPRESS_RUNNING_ENV') === 'prod' ? ACCOUNT_PROD : ACCOUNT_STAGE;
-
-export const permanentKb = {
-  name: 'permanent',
-  slug: 'permanent',
-  id: Cypress.env('CYPRESS_RUNNING_ENV') === 'prod' ? 'f639477f-dd3d-4509-b278-7ab20ff73bd1' : '096d9070-f7be-40c8-a24c-19c89072e3ff',
-  zone: ZONES['europe'],
-};
-export const emptyKb = {
-  name: 'permanent-empty',
-  slug: 'permanent-empty',
-  id: Cypress.env('CYPRESS_RUNNING_ENV') === 'prod' ? '6176242a-b15d-459b-b4b9-5740fc1fed72' : '1efc5a33-bc5a-490c-8b47-b190beee212d',
-  zone: ZONES['europe'],
-};
+export const ACCOUNT = `${Cypress.env('CYPRESS_RUNNING_ENV')}` === 'prod' ? ACCOUNT_PROD : ACCOUNT_STAGE;
 
 export const user = {
   email: `${Cypress.env('USER_NAME')}`,
@@ -60,33 +84,32 @@ export function getAuthHeader(synchronous = true) {
   return headers;
 }
 
-/**
- * Keep only permanent KB on specified zone and account.
- * @param zone europe | usa
- */
-export function onlyPermanentKb(zone = 'europe') {
+export function onlyPermanentKb() {
   const authHeader = { Authorization: `Bearer ${Cypress.env('BEARER_TOKEN')}` };
-  cy.request({
-    method: 'GET',
-    url: `https://${ZONES[zone]}.${ACCOUNT.domain}/api/v1/account/${ACCOUNT.id}/kbs`,
-    headers: authHeader,
-  }).then((response) => {
-    expect(response.status).to.eq(200);
+  ACCOUNT.availableZones.forEach((zone) => {
+    cy.request({
+      method: 'GET',
+      url: `https://${zone.slug}.${ACCOUNT.domain}/api/v1/account/${ACCOUNT.id}/kbs`,
+      headers: authHeader,
+    }).then((response) => {
+      expect(response.status).to.eq(200);
 
-    if (response.body.length > 2) {
-      response.body.forEach((kb) => {
-        if (!kb.slug.includes('permanent')) {
-          cy.request({
-            method: 'DELETE',
-            url: `https://${ACCOUNT.domain}/api/v1/account/${ACCOUNT.slug}/kb/${kb.slug}`,
-            headers: authHeader,
-          }).then((deleteResponse) => {
-            expect(deleteResponse.status).to.eq(204);
-          });
-        }
-      });
-    }
+      if (response.body.length > 2) {
+        response.body.forEach((kb) => {
+          if (!kb.slug.includes('permanent')) {
+            cy.request({
+              method: 'DELETE',
+              url: `https://${ACCOUNT.domain}/api/v1/account/${ACCOUNT.slug}/kb/${kb.slug}`,
+              headers: authHeader,
+            }).then((deleteResponse) => {
+              expect(deleteResponse.status).to.eq(204);
+            });
+          }
+        });
+      }
+    });
   });
+
 }
 
 export const goTo = (navbarItemSelector, popup = false) => {


### PR DESCRIPTION
- Regroup all account and KB properties used in e2e tests into one `ACCOUNT` object (one by environement). 
- Run the tests against available zones on the environement tested

