### PR TITLE
Enable retries when tests are failing

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -27,6 +27,10 @@ module.exports = defineConfig({
     env: {
       STANDALONE_KB_NAME: 'standalone-kb',
       NUCLIA_DB_ADMIN_URL: 'http://0.0.0.0:8080/admin',
+    },
+    retries: {
+      openMode: 0,
+      runMode: 1
     }
   }
 });

--- a/cypress/e2e/3-widget/ask.cy.js
+++ b/cypress/e2e/3-widget/ask.cy.js
@@ -18,7 +18,7 @@ import {
 } from '../selectors/widget-selectors';
 import { ACCOUNT } from '../../support/common';
 
-describe('Ask', () => {
+describe('Ask', {retries: {openMode: 0, runMode: 2}}, () => {
   ACCOUNT.availableZones.forEach((zone) => {
     describe(`on ${zone.slug}`, () => {
       beforeEach(() => {


### PR DESCRIPTION
By default, retry failing tests once. For `ask` test suite, retry twice in case of failure.