### PR TITLE
Upgrade to actions/upload-artifact@v4

### DIFF
--- a/.github/workflows/run-e2e-prod.yml
+++ b/.github/workflows/run-e2e-prod.yml
@@ -39,7 +39,7 @@ jobs:
           CYPRESS_RUNNING_ENV: prod
         # after the test run completes store reports and any screenshots
       - name: Cypress reports
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ failure() && steps.cypress.conclusion == 'failure' }}
         with:
           name: cypress-reports
@@ -52,7 +52,7 @@ jobs:
         with:
           payload: |
             {
-              "text": "‼️⚠️ Cypress E2E job #${{ github.run_number }} failed on Prod ‼️\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              "text": "‼️⚠️ Cypress E2E failed on Prod ‼️\nRun #${{ github.run_number }}: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\n📜Cypress report: ${{ steps.report.outputs.artifact-url }}"
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_HOOK_URL }}

--- a/.github/workflows/run-e2e-stage.yml
+++ b/.github/workflows/run-e2e-stage.yml
@@ -46,7 +46,7 @@ jobs:
         # after the test run completes store reports and any screenshots
       - name: Cypress reports
         id: report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ failure() && steps.cypress.conclusion == 'failure' }}
         with:
           name: cypress-reports


### PR DESCRIPTION
v3 doesn't have outputs, while v4 has the artifact id and URL as outputs, allowing us to use them in the notification.