### PR TITLE
Fix base url on prod

### DIFF
--- a/.github/workflows/run-e2e-prod.yml
+++ b/.github/workflows/run-e2e-prod.yml
@@ -7,9 +7,9 @@ on:
   workflow_dispatch:
     branches:
       - e2e-on-prod
-#  schedule:
-#    # Run at minute 35 past every 3rd hour on every day-of-week from Sunday through Saturday.
-#    - cron: '45 */3 * * 0-6'
+  schedule:
+    # Run at minute 35 past every 3rd hour on every day-of-week from Sunday through Saturday.
+    - cron: '45 */3 * * 0-6'
 jobs:
   cypress-run:
     runs-on: ubuntu-22.04
@@ -31,6 +31,7 @@ jobs:
         with:
           install-command: yarn install
         env:
+          CYPRESS_BASE_URL: https://nuclia.cloud
           CYPRESS_BEARER_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN_PROD }}
           CYPRESS_NUA_KEY_EUROPE: ${{ secrets.NUA_KEY_PROD_EUROPE }}
           CYPRESS_NUA_KEY_USA: ${{ secrets.NUA_KEY_PROD_USA }}

--- a/.github/workflows/run-e2e-stage.yml
+++ b/.github/workflows/run-e2e-stage.yml
@@ -38,6 +38,7 @@ jobs:
         with:
           install-command: yarn install
         env:
+          CYPRESS_BASE_URL: https://stashify.cloud
           CYPRESS_BEARER_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           CYPRESS_NUA_KEY: ${{ secrets.NUA_KEY }}
           CYPRESS_USER_NAME: ${{ secrets.USER_NAME }}

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -9,17 +9,16 @@ module.exports = defineConfig({
   reporterOptions: {
     overwrite: false,
     html: false,
-    json: true
+    json: true,
   },
   e2e: {
-    baseUrl: 'https://stashify.cloud',
     setupNodeEvents(on) {
       // Enable ability to log to the terminal from the tests
       on('task', {
         log(message) {
           console.log(`    ${message}`);
           return null;
-        }
+        },
       });
       // Load plugins
       require('cypress-mochawesome-reporter/plugin')(on);
@@ -30,7 +29,7 @@ module.exports = defineConfig({
     },
     retries: {
       openMode: 0,
-      runMode: 1
-    }
-  }
+      runMode: 1,
+    },
+  },
 });


### PR DESCRIPTION
We used to change the baseUrl directly in cypress.config.js of e2e-on-prod branch, but this wasn't working well in the scheduler.