### PR TITLE
Enable repository dispatch trigger on run-e2e-prod

### DIFF
--- a/.github/workflows/run-e2e-prod.yml
+++ b/.github/workflows/run-e2e-prod.yml
@@ -8,8 +8,10 @@ on:
     branches:
       - e2e-on-prod
   schedule:
-    # Run at minute 35 past every 3rd hour on every day-of-week from Sunday through Saturday.
+    # Run at minute 45 past every 3rd hour on every day-of-week from Sunday through Saturday.
     - cron: '45 */3 * * 0-6'
+  repository_dispatch:
+    types: [trigger_e2e]
 jobs:
   cypress-run:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Enable ability to trigger e2e on prod from another repo, so we can run the e2e on prod whenever we promote the Dashboard on prod.