### PR TITLE
Prevent jobs of a same workflow to run simultaneously

### DIFF
--- a/.github/workflows/run-e2e-prod.yml
+++ b/.github/workflows/run-e2e-prod.yml
@@ -12,6 +12,9 @@ on:
     - cron: '45 */3 * * 0-6'
   repository_dispatch:
     types: [trigger_e2e]
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
 jobs:
   cypress-run:
     runs-on: ubuntu-22.04

--- a/.github/workflows/run-e2e-stage.yml
+++ b/.github/workflows/run-e2e-stage.yml
@@ -16,6 +16,9 @@ on:
     - cron: 25 0-19 * * 5
     # Run at 00:25 and 12:25 on saturday and sunday
     - cron: '25 0,12 * * 0,6'
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
 jobs:
   cypress-run:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
We don't want several runs of a same workflow (stage/prod) to run at the same time.