### PR TITLE
Wait for citation block to appear AFTER getting the answer

### DIFF
--- a/cypress/e2e/3-widget/ask.cy.js
+++ b/cypress/e2e/3-widget/ask.cy.js
@@ -73,11 +73,11 @@ describe('Ask', () => {
           .type(`${secondQuestion}\n`, { force: true });
         cy.get(nucliaSearchResultsSelector)
           .shadow()
-          .find(`${initialAnswerSelector} ${answerContainerSelector}`, { timeout: 10000 })
+          .find(`${initialAnswerSelector} ${answerContainerSelector}`, { timeout: 8000 })
           .should('exist');
         cy.get(nucliaSearchResultsSelector)
           .shadow()
-          .find(`${initialAnswerSelector} ${answerCitationSelector}`)
+          .find(`${initialAnswerSelector} ${answerCitationSelector}`, { timeout: 6000 })
           .should('contain', 1);
         cy.get(nucliaSearchResultsSelector)
           .shadow()


### PR DESCRIPTION
We had a 10s timeout to get the answer, but actually it's the citation block which is slow to be displayed after we get the answer itself. So we put back the same 8s to get answer (as in the other test) and we add a 6s timeout on getting citations afterward.