### PR TITLE
Don't wait too long for tasks to complete

### DIFF
--- a/nuclia_e2e/nuclia_e2e/tests/nua/test_da_tasks.py
+++ b/nuclia_e2e/nuclia_e2e/tests/nua/test_da_tasks.py
@@ -136,7 +136,7 @@ async def wait_for_task_completion(
     client: aiohttp.ClientSession,
     dataset_id: str,
     task_id: str,
-    max_duration: int = 2300,
+    max_duration: int = 300,
 ):
     start_time = asyncio.get_event_loop().time()
     while True:


### PR DESCRIPTION
in the tasks of this tests, 160 seconds is the usuall, but of course if running out of resources on the worker manager that can affect, so let's wait a little bit longer.

At the time of writing, 250 is the longer test. as they run concurrently, 300 doesn't add too much on top of the total run time