### PR TITLE
Disable llama guard on prod

### DIFF
--- a/nuclia_e2e/nuclia_e2e/tests/nua/test_da_tasks.py
+++ b/nuclia_e2e/nuclia_e2e/tests/nua/test_da_tasks.py
@@ -33,7 +33,7 @@ import json
 import pytest
 
 LLAMA_GUARD_DISABLED = True
-PROMPT_GUARD_DISABLED = True
+PROMPT_GUARD_DISABLED = TEST_ENV == "prod"
 
 
 def get_grafana_task_url(task_id: str) -> str:

--- a/nuclia_e2e/nuclia_e2e/tests/nua/test_da_tasks.py
+++ b/nuclia_e2e/nuclia_e2e/tests/nua/test_da_tasks.py
@@ -32,8 +32,8 @@ import base64
 import json
 import pytest
 
-LLAMA_GUARD_DISABLED = TEST_ENV == "prod"
-PROMPT_GUARD_DISABLED = TEST_ENV == "prod"
+LLAMA_GUARD_DISABLED = True
+PROMPT_GUARD_DISABLED = True
 
 
 def get_grafana_task_url(task_id: str) -> str:


### PR DESCRIPTION
The triton deployment required for the task was disabled to save costs.