### PR TITLE
Capture ndb standalone logs and workflow improvements

### DIFF
--- a/.github/workflows/run-e2e-nuclia-prod.yml
+++ b/.github/workflows/run-e2e-nuclia-prod.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - '**'
     paths:
-      - '.github/workflows/run-nuclia-e2e-prod.yml'  # Runs only if this file is modified
+      - '.github/workflows/run-e2e-nuclia-prod.yml'  # Runs only if this file is modified
   workflow_dispatch:  # Allow manual run from any branch
   schedule:
     # Run every day at 04:25

--- a/.github/workflows/run-e2e-nuclia-prod.yml
+++ b/.github/workflows/run-e2e-nuclia-prod.yml
@@ -4,11 +4,11 @@ on:
   push:
     branches:
       - '**'
-  workflow_dispatch:
-    branches:
-      - main
+    paths:
+      - '.github/workflows/run-nuclia-e2e-prod.yml'  # Runs only if this file is modified
+  workflow_dispatch:  # Allow manual run from any branch
   schedule:
-    # run every day at 04:25
+    # Run every day at 04:25
     - cron: '25 4 * * *'
 jobs:
   test:

--- a/.github/workflows/run-e2e-nuclia-stage.yml
+++ b/.github/workflows/run-e2e-nuclia-stage.yml
@@ -5,11 +5,12 @@ on:
   push:
     branches:
       - '**'
-  workflow_dispatch:
-    branches:
-      - main
+    paths:
+      - '.github/workflows/run-e2e-nuclia-stage.yml'
+      - 'nuclia_e2e/**'
+  workflow_dispatch:  # Allow manual run from any branch
   schedule:
-    # run every day at 04:25
+    # Run every day at 04:25
     - cron: '25 4 * * *'
 jobs:
   test:

--- a/.github/workflows/run-e2e-prod.yml
+++ b/.github/workflows/run-e2e-prod.yml
@@ -64,6 +64,22 @@ jobs:
           name: cypress-reports
           path: cypress/reports
           if-no-files-found: ignore # 'warn' or 'error' are also available, defaults to `warn`
+      # After Cypress tests, get logs and upload them
+      - name: Capture NucliaDB Logs
+        if: always() # Run even if Cypress fails
+        run: |
+          docker logs nucliadb-server > nucliadb-server.log
+          docker logs pg > postgres.log
+    
+      - name: Upload Docker Logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: docker-logs
+          path: |
+            nucliadb-server.log
+            postgres.log
+          if-no-files-found: ignore          
       - name: Slack notification
         id: slack
         uses: slackapi/slack-github-action@v1.25.0

--- a/.github/workflows/run-e2e-prod.yml
+++ b/.github/workflows/run-e2e-prod.yml
@@ -36,9 +36,11 @@ jobs:
           docker build -t nucliadb-server .
           docker run --network nucliadb-network \
               -p 8080:8080 \
+              --name nucliadb-server \
               -v nucliadb-standalone:/data \
               -e NUA_API_KEY=${{ secrets.NUA_KEY_PROD_EUROPE }} \
               -e DRIVER=PG \
+              -e LOG_LEVEL=DEBUG \
               -e DRIVER_PG_URL="postgresql://nucliadb:nucliadb@pg:5432/nucliadb" \
               nucliadb-server &
       # Install npm dependencies, cache them correctly and run all Cypress tests
@@ -68,7 +70,7 @@ jobs:
       - name: Capture NucliaDB Logs
         if: always() # Run even if Cypress fails
         run: |
-          docker logs nucliadb-server > nucliadb-server.log
+          docker logs nucliadb-server > nucliadb-server.log 2>&1
           docker logs pg > postgres.log
     
       - name: Upload Docker Logs
@@ -79,7 +81,7 @@ jobs:
           path: |
             nucliadb-server.log
             postgres.log
-          if-no-files-found: ignore          
+          if-no-files-found: ignore            
       - name: Slack notification
         id: slack
         uses: slackapi/slack-github-action@v1.25.0

--- a/.github/workflows/run-e2e-prod.yml
+++ b/.github/workflows/run-e2e-prod.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - e2e-on-prod
+    paths:
+      - '.github/workflows/run-e2e-prod.yml'
   workflow_dispatch:
     branches:
       - e2e-on-prod

--- a/.github/workflows/run-e2e-stage.yml
+++ b/.github/workflows/run-e2e-stage.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Capture NucliaDB Logs
         if: always() # Run even if Cypress fails
         run: |
-          docker logs nucliadb-server > nucliadb-server.log
+          docker logs nucliadb-server > nucliadb-server.log 2>&1
           docker logs pg > postgres.log
     
       - name: Upload Docker Logs

--- a/.github/workflows/run-e2e-stage.yml
+++ b/.github/workflows/run-e2e-stage.yml
@@ -31,10 +31,10 @@ jobs:
           docker pull nuclia/nucliadb:latest
           docker build -t nucliadb-server .
           docker run --network nucliadb-network \
+              --name nucliadb-server \
               -p 8080:8080 \
               -v nucliadb-standalone:/data \
-              -e NUCLIA_PUBLIC_URL="https://{zone}.stashify.cloud" \
-              -e NUA_API_KEY=${{ secrets.NUA_KEY }} \
+              -e NUA_API_KEY=${{ secrets.NUA_KEY_PROD_EUROPE }} \
               -e DRIVER=PG \
               -e DRIVER_PG_URL="postgresql://nucliadb:nucliadb@pg:5432/nucliadb" \
               nucliadb-server &

--- a/.github/workflows/run-e2e-stage.yml
+++ b/.github/workflows/run-e2e-stage.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - '**'
+    paths:
+      - '.github/workflows/run-e2e-stage.yml'
+      - 'nuclia_e2e/**'      
   workflow_dispatch:
     branches:
       - main

--- a/.github/workflows/run-e2e-stage.yml
+++ b/.github/workflows/run-e2e-stage.yml
@@ -60,6 +60,22 @@ jobs:
           name: cypress-reports
           path: cypress/reports
           if-no-files-found: ignore # 'warn' or 'error' are also available, defaults to `warn`
+      # After Cypress tests, get logs and upload them
+      - name: Capture NucliaDB Logs
+        if: always() # Run even if Cypress fails
+        run: |
+          docker logs nucliadb-server > nucliadb-server.log
+          docker logs pg > postgres.log
+    
+      - name: Upload Docker Logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: docker-logs
+          path: |
+            nucliadb-server.log
+            postgres.log
+          if-no-files-found: ignore          
       - name: Slack notification
         id: slack
         uses: slackapi/slack-github-action@v1.25.0

--- a/.github/workflows/run-e2e-stage.yml
+++ b/.github/workflows/run-e2e-stage.yml
@@ -34,7 +34,8 @@ jobs:
               --name nucliadb-server \
               -p 8080:8080 \
               -v nucliadb-standalone:/data \
-              -e NUA_API_KEY=${{ secrets.NUA_KEY_PROD_EUROPE }} \
+              -e NUCLIA_PUBLIC_URL="https://{zone}.stashify.cloud" \
+              -e NUA_API_KEY=${{ secrets.NUA_KEY }} \
               -e DRIVER=PG \
               -e DRIVER_PG_URL="postgresql://nucliadb:nucliadb@pg:5432/nucliadb" \
               nucliadb-server &

--- a/.github/workflows/run-e2e-stage.yml
+++ b/.github/workflows/run-e2e-stage.yml
@@ -6,7 +6,7 @@ on:
       - '**'
     paths:
       - '.github/workflows/run-e2e-stage.yml'
-      - 'nuclia_e2e/**'      
+      - 'e2e/**'      
   workflow_dispatch:
     branches:
       - main

--- a/.github/workflows/run-e2e-stage.yml
+++ b/.github/workflows/run-e2e-stage.yml
@@ -36,6 +36,7 @@ jobs:
               -v nucliadb-standalone:/data \
               -e NUCLIA_PUBLIC_URL="https://{zone}.stashify.cloud" \
               -e NUA_API_KEY=${{ secrets.NUA_KEY }} \
+              -e LOG_LEVEL=DEBUG \
               -e DRIVER=PG \
               -e DRIVER_PG_URL="postgresql://nucliadb:nucliadb@pg:5432/nucliadb" \
               nucliadb-server &

--- a/.github/workflows/run-e2e-stage.yml
+++ b/.github/workflows/run-e2e-stage.yml
@@ -6,7 +6,7 @@ on:
       - '**'
     paths:
       - '.github/workflows/run-e2e-stage.yml'
-      - 'e2e/**'      
+      - 'cypress/**'      
   workflow_dispatch:
     branches:
       - main

--- a/nuclia_e2e/nuclia_e2e/tests/test_kb_features.py
+++ b/nuclia_e2e/nuclia_e2e/tests/test_kb_features.py
@@ -629,6 +629,8 @@ async def test_kb_usage(request: pytest.FixtureRequest, regional_api_config, glo
     )
 
     accounting_tokens = await run_test_tokens_on_accounting(global_api, account, kbid, logger)
+    # Disable check nuclia tokens on activity log for now, as under heavy loads it takes several hours
+    # to be up to date, and so the logs won't be available on most of the tests runs.
     await run_test_tokens_on_activity_log(async_ndb, accounting_tokens, logger)
 
     # Delete the kb as a final step


### PR DESCRIPTION
- Store nucliadb standalone container logs as an artifact
- modify when the workflows are run on code changes, to avoid innecessary cross runs between cypress/nuclia tests 
- modify tests so only stage tests are used as validation for merging, unless the prod workflow files are edited