### PR TITLE
Avoid empty POST to stop tasks

### DIFF
--- a/nuclia_e2e/nuclia_e2e/tests/nua/test_da_tasks.py
+++ b/nuclia_e2e/nuclia_e2e/tests/nua/test_da_tasks.py
@@ -149,7 +149,7 @@ async def start_task(
 
 
 async def stop_task(client: aiohttp.ClientSession, dataset_id: str, task_id: str):
-    resp = await client.post(f"/api/v1/dataset/{dataset_id}/task/{task_id}/stop")
+    resp = await client.post(f"/api/v1/dataset/{dataset_id}/task/{task_id}/stop", json={})
     assert resp.status == 200, await resp.text()
 
 


### PR DESCRIPTION
We had a problem when senting an empty POST triggered a 411 response from Google's load balancer. This is a known issue where the LB is deviating slightly from the standards (RFC7230, 3.3.3). So we send a semantically empty body but with actual length in order to make sure a Content-Length header is sent.

This mimics how frontend does the query, sending an empty JSON model, so we get E2E that are closer to real world usage.