### PR TITLE
Add tests for default model configs

### DIFF
--- a/.github/workflows/run-e2e-nuclia-stage.yml
+++ b/.github/workflows/run-e2e-nuclia-stage.yml
@@ -86,7 +86,7 @@ jobs:
         run: |
           source nuclia_e2e/.venv/bin/activate && TEST_ENV=stage pytest -sxv -r fEs nuclia_e2e/nuclia_e2e/tests \
             --durations=0 --junitxml=nuclia-${{ matrix.shard_index }}.xml \
-            --shard-id=${{ matrix.shard_index }} --num-shards=3
+            --shard-id=${{ matrix.shard_index }} --num-shards=3 -k for_gene
 
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v4

--- a/.github/workflows/run-e2e-nuclia-stage.yml
+++ b/.github/workflows/run-e2e-nuclia-stage.yml
@@ -86,7 +86,7 @@ jobs:
         run: |
           source nuclia_e2e/.venv/bin/activate && TEST_ENV=stage pytest -sxv -r fEs nuclia_e2e/nuclia_e2e/tests \
             --durations=0 --junitxml=nuclia-${{ matrix.shard_index }}.xml \
-            --shard-id=${{ matrix.shard_index }} --num-shards=3 -k for_gene
+            --shard-id=${{ matrix.shard_index }} --num-shards=3
 
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v4

--- a/nuclia_e2e/nuclia_e2e/tests/test_custom_models.py
+++ b/nuclia_e2e/nuclia_e2e/tests/test_custom_models.py
@@ -93,7 +93,9 @@ async def _test_generative(kb_id: str, zone: str, auth: AsyncNucliaAuth, generat
     extra_params = {}
     if generative_model:
         extra_params["generative_model"] = generative_model
-    answer = await sdk.AsyncNucliaSearch().ask(ndb=ndb, query="how to cook an omelette?", **extra_params)
+    answer = await sdk.AsyncNucliaSearch().ask(
+        ndb=ndb, query="how to cook an omelette? Answer in less than 200 words please.", **extra_params
+    )
     assert answer.answer is not None
     assert answer.status is not None
     assert answer.status == "success"

--- a/nuclia_e2e/nuclia_e2e/tests/test_custom_models.py
+++ b/nuclia_e2e/nuclia_e2e/tests/test_custom_models.py
@@ -1,13 +1,10 @@
 from collections.abc import AsyncIterator
 from nuclia import sdk
 from nuclia.sdk.auth import AsyncNucliaAuth
-from nuclia_e2e.tests.conftest import ZoneConfig
 from nuclia_e2e.tests.utils import as_default_generative_model_for_kb
 from nuclia_e2e.tests.utils import clean_ask_test_tasks
 from nuclia_e2e.tests.utils import create_ask_agent
 from nuclia_e2e.tests.utils import CustomModels
-from nuclia_e2e.utils import create_test_kb
-from nuclia_e2e.utils import delete_test_kb
 from nuclia_e2e.utils import get_async_kb_ndb_client
 
 import os
@@ -19,15 +16,6 @@ TEST_ENV = os.environ.get("TEST_ENV")
 # Global variable to know which tasks were created in this test
 # suite so we can clean them up properly on fixture teardown
 _tasks_to_delete: list[str] = []
-
-
-@pytest.fixture
-async def kb_id(regional_api_config: ZoneConfig) -> AsyncIterator[str]:
-    unique_id = uuid.uuid4().hex
-    kb_slug = f"custom-models-test-can-delete-{unique_id}"
-    kbid = await create_test_kb(regional_api_config, kb_slug)
-    yield kbid
-    await delete_test_kb(regional_api_config, kbid, kb_slug)
 
 
 @pytest.fixture

--- a/nuclia_e2e/nuclia_e2e/tests/test_custom_models.py
+++ b/nuclia_e2e/nuclia_e2e/tests/test_custom_models.py
@@ -1,14 +1,10 @@
 from collections.abc import AsyncIterator
 from nuclia import sdk
 from nuclia.sdk.auth import AsyncNucliaAuth
-from nuclia_e2e.tests.conftest import ZoneConfig
 from nuclia_e2e.tests.utils import as_default_generative_model_for_kb
 from nuclia_e2e.tests.utils import clean_ask_test_tasks
 from nuclia_e2e.tests.utils import create_ask_agent
-from nuclia_e2e.tests.utils import create_omelette_resource
 from nuclia_e2e.tests.utils import CustomModels
-from nuclia_e2e.utils import create_test_kb
-from nuclia_e2e.utils import delete_test_kb
 from nuclia_e2e.utils import get_async_kb_ndb_client
 
 import os
@@ -20,23 +16,6 @@ TEST_ENV = os.environ.get("TEST_ENV")
 # Global variable to know which tasks were created in this test
 # suite so we can clean them up properly on fixture teardown
 _tasks_to_delete: list[str] = []
-
-
-@pytest.fixture
-async def kb_id(regional_api_config: ZoneConfig, auth: AsyncNucliaAuth) -> AsyncIterator[str]:
-    unique_id = uuid.uuid4().hex
-    kb_slug = f"custom-models-test-can-delete-{unique_id}"
-    kbid = await create_test_kb(regional_api_config, kb_slug)
-
-    ndb = get_async_kb_ndb_client(
-        zone=regional_api_config.zone_slug, kbid=kbid, user_token=auth._config.token
-    )
-    auth.default_kb(kbid)
-    await create_omelette_resource(ndb)
-
-    yield kbid
-
-    await delete_test_kb(regional_api_config, kbid, kb_slug)
 
 
 @pytest.fixture

--- a/nuclia_e2e/nuclia_e2e/tests/test_custom_models.py
+++ b/nuclia_e2e/nuclia_e2e/tests/test_custom_models.py
@@ -1,8 +1,6 @@
 from collections.abc import AsyncIterator
 from nuclia import sdk
-from nuclia.data import get_async_auth
 from nuclia.sdk.auth import AsyncNucliaAuth
-from nuclia_e2e.tests.conftest import ZoneConfig
 from nuclia_e2e.tests.utils import as_default_generative_model_for_kb
 from nuclia_e2e.tests.utils import clean_ask_test_tasks
 from nuclia_e2e.tests.utils import create_ask_agent
@@ -18,42 +16,6 @@ TEST_ENV = os.environ.get("TEST_ENV")
 # Global variable to know which tasks were created in this test
 # suite so we can clean them up properly on fixture teardown
 _tasks_to_delete: list[str] = []
-
-
-@pytest.fixture
-async def kb_id(regional_api_config: ZoneConfig) -> str:
-    """
-    Fixture to provide the knowledge base ID for the tests.
-    """
-    assert regional_api_config.global_config is not None
-    return regional_api_config.permanent_kb_id
-
-
-@pytest.fixture
-async def zone(regional_api_config: ZoneConfig) -> str:
-    """
-    Fixture to provide the zone slug for the tests.
-    """
-    return regional_api_config.zone_slug
-
-
-@pytest.fixture
-def auth() -> AsyncNucliaAuth:
-    """
-    Fixture to provide the async Nuclia authentication object.
-    """
-    return get_async_auth()
-
-
-@pytest.fixture(autouse=True)
-async def account_id(regional_api_config: ZoneConfig, auth: AsyncNucliaAuth) -> str:
-    """
-    Fixture to provide the account slug for the tests.
-    """
-    assert regional_api_config.global_config is not None
-    account_slug = regional_api_config.global_config.permanent_account_slug
-    sdk.NucliaAccounts().default(account_slug)
-    return auth.get_account_id(account_slug)
 
 
 @pytest.fixture

--- a/nuclia_e2e/nuclia_e2e/tests/test_custom_models.py
+++ b/nuclia_e2e/nuclia_e2e/tests/test_custom_models.py
@@ -39,7 +39,7 @@ async def custom_model(kb_id: str, custom_models: CustomModels) -> str:
     model_id = "custom:qwen3-8b"
     custom_list = await custom_models.list()
     try:
-        next(m for m in custom_list if m["model_id"] == model_id)
+        next(m for m in custom_list if m["location"] == model_id)
     except StopIteration:
         # Configure a new custom generative model
         await custom_models.add(

--- a/nuclia_e2e/nuclia_e2e/tests/test_custom_models.py
+++ b/nuclia_e2e/nuclia_e2e/tests/test_custom_models.py
@@ -79,14 +79,12 @@ async def test_custom_models_work_for_generative_and_agents(
     custom_model: str,
     clean_tasks: None,
 ):
-    await _test_generative(kb_id, zone, auth, generative_model=custom_model)
-    await _test_run_resource_agents(
-        kb_id, zone, auth, generative_model=custom_model, generative_model_provider="custom"
-    )
-
     async with as_default_generative_model_for_kb(kb_id, zone, auth, custom_model):
-        # Do not specify the custom model -- it should use the default one
         await _test_generative(kb_id, zone, auth, generative_model=None)
+        await _test_generative(kb_id, zone, auth, generative_model=custom_model)
+        await _test_run_resource_agents(
+            kb_id, zone, auth, generative_model=custom_model, generative_model_provider="custom"
+        )
 
 
 async def _test_generative(kb_id: str, zone: str, auth: AsyncNucliaAuth, generative_model: str | None = None):

--- a/nuclia_e2e/nuclia_e2e/tests/test_custom_models.py
+++ b/nuclia_e2e/nuclia_e2e/tests/test_custom_models.py
@@ -1,10 +1,13 @@
 from collections.abc import AsyncIterator
 from nuclia import sdk
 from nuclia.sdk.auth import AsyncNucliaAuth
+from nuclia_e2e.tests.conftest import ZoneConfig
 from nuclia_e2e.tests.utils import as_default_generative_model_for_kb
 from nuclia_e2e.tests.utils import clean_ask_test_tasks
 from nuclia_e2e.tests.utils import create_ask_agent
 from nuclia_e2e.tests.utils import CustomModels
+from nuclia_e2e.utils import create_test_kb
+from nuclia_e2e.utils import delete_test_kb
 from nuclia_e2e.utils import get_async_kb_ndb_client
 
 import os
@@ -16,6 +19,15 @@ TEST_ENV = os.environ.get("TEST_ENV")
 # Global variable to know which tasks were created in this test
 # suite so we can clean them up properly on fixture teardown
 _tasks_to_delete: list[str] = []
+
+
+@pytest.fixture
+async def kb_id(regional_api_config: ZoneConfig) -> AsyncIterator[str]:
+    unique_id = uuid.uuid4().hex
+    kb_slug = f"custom-models-test-can-delete-{unique_id}"
+    kbid = await create_test_kb(regional_api_config, kb_slug)
+    yield kbid
+    await delete_test_kb(regional_api_config, kbid, kb_slug)
 
 
 @pytest.fixture

--- a/nuclia_e2e/nuclia_e2e/tests/test_custom_models.py
+++ b/nuclia_e2e/nuclia_e2e/tests/test_custom_models.py
@@ -25,7 +25,9 @@ async def clean_tasks(kb_id: str, zone: str, auth: AsyncNucliaAuth) -> AsyncIter
 
     yield
 
-    await clean_ask_test_tasks(kb, ndb, to_delete=_tasks_to_delete)
+    if _tasks_to_delete:
+        await clean_ask_test_tasks(kb, ndb, to_delete=_tasks_to_delete)
+        _tasks_to_delete.clear()
 
 
 @pytest.fixture

--- a/nuclia_e2e/nuclia_e2e/tests/test_custom_models.py
+++ b/nuclia_e2e/nuclia_e2e/tests/test_custom_models.py
@@ -1,10 +1,14 @@
 from collections.abc import AsyncIterator
 from nuclia import sdk
 from nuclia.sdk.auth import AsyncNucliaAuth
+from nuclia_e2e.tests.conftest import ZoneConfig
 from nuclia_e2e.tests.utils import as_default_generative_model_for_kb
 from nuclia_e2e.tests.utils import clean_ask_test_tasks
 from nuclia_e2e.tests.utils import create_ask_agent
+from nuclia_e2e.tests.utils import create_omelette_resource
 from nuclia_e2e.tests.utils import CustomModels
+from nuclia_e2e.utils import create_test_kb
+from nuclia_e2e.utils import delete_test_kb
 from nuclia_e2e.utils import get_async_kb_ndb_client
 
 import os
@@ -16,6 +20,22 @@ TEST_ENV = os.environ.get("TEST_ENV")
 # Global variable to know which tasks were created in this test
 # suite so we can clean them up properly on fixture teardown
 _tasks_to_delete: list[str] = []
+
+
+@pytest.fixture
+async def kb_id(regional_api_config: ZoneConfig, auth: AsyncNucliaAuth) -> AsyncIterator[str]:
+    unique_id = uuid.uuid4().hex
+    kb_slug = f"custom-models-test-can-delete-{unique_id}"
+    kbid = await create_test_kb(regional_api_config, kb_slug)
+
+    ndb = get_async_kb_ndb_client(
+        zone=regional_api_config.zone_slug, kbid=kbid, user_token=auth._config.token
+    )
+    await create_omelette_resource(ndb)
+
+    yield kbid
+
+    await delete_test_kb(regional_api_config, kbid, kb_slug)
 
 
 @pytest.fixture

--- a/nuclia_e2e/nuclia_e2e/tests/test_custom_models.py
+++ b/nuclia_e2e/nuclia_e2e/tests/test_custom_models.py
@@ -121,7 +121,7 @@ async def _test_run_resource_agents(
         question="Summarize the contents of the document in a single sentence.",
         generative_model=generative_model,
         generative_model_provider=generative_model_provider,
-        destination_field_prefix=f"summary-{unique_id}",
+        destination_field_prefix=f"summary_{unique_id}",
     )
 
     # Add to the list

--- a/nuclia_e2e/nuclia_e2e/tests/test_custom_models.py
+++ b/nuclia_e2e/nuclia_e2e/tests/test_custom_models.py
@@ -34,7 +34,7 @@ async def custom_models(auth: AsyncNucliaAuth, zone: str, account_id: str) -> Cu
 
 
 @pytest.fixture
-async def custom_model(kb_id: str, custom_models: CustomModels) -> AsyncIterator[str]:
+async def custom_model(kb_id: str, custom_models: CustomModels) -> str:
     # Make sure there are no custom models configured
     await custom_models.remove_all()
     assert len(await custom_models.list()) == 0
@@ -66,11 +66,7 @@ async def custom_model(kb_id: str, custom_models: CustomModels) -> AsyncIterator
         kbs=[kb_id],
     )
 
-    yield model
-
-    # Remove the custom model
-    await custom_models.remove_all()
-    assert len(await custom_models.list()) == 0
+    return model
 
 
 @pytest.mark.asyncio_cooperative
@@ -112,7 +108,7 @@ async def _test_run_resource_agents(
     ndb = get_async_kb_ndb_client(zone=zone, kbid=kb_id, user_token=auth._config.token)
 
     # Configure an ingestion agent (aka task)
-    unique_id = str(uuid.uuid4())
+    unique_id = uuid.uuid4().hex
     agent_id = await create_ask_agent(
         kb_id,
         zone,

--- a/nuclia_e2e/nuclia_e2e/tests/test_custom_models.py
+++ b/nuclia_e2e/nuclia_e2e/tests/test_custom_models.py
@@ -36,16 +36,16 @@ async def custom_models(auth: AsyncNucliaAuth, zone: str, account_id: str) -> Cu
 @pytest.fixture
 async def custom_model(kb_id: str, custom_models: CustomModels) -> str:
     # This model has been added to the vLLM server of the gke-stage-1 cluster for testing purposes
-    model_id = "custom:qwen3-8b"
+    model_location = "custom:qwen3-8b"
     custom_list = await custom_models.list()
     try:
-        next(m for m in custom_list if m["location"] == model_id)
+        next(m for m in custom_list if m["location"] == model_location)
     except StopIteration:
         # Configure a new custom generative model
         await custom_models.add(
             model_data={
                 "description": "test_model",
-                "location": model_id,
+                "location": model_location,
                 "model_types": ["GENERATIVE", "SUMMARY"],
                 "openai_compat": {
                     "url": "http://vllm-stack-router-service.vllm-stack.svc.cluster.local/v1",
@@ -64,7 +64,7 @@ async def custom_model(kb_id: str, custom_models: CustomModels) -> str:
             },
             kbs=[kb_id],
         )
-    return model_id
+    return model_location
 
 
 @pytest.mark.asyncio_cooperative

--- a/nuclia_e2e/nuclia_e2e/tests/test_custom_models.py
+++ b/nuclia_e2e/nuclia_e2e/tests/test_custom_models.py
@@ -31,6 +31,7 @@ async def kb_id(regional_api_config: ZoneConfig, auth: AsyncNucliaAuth) -> Async
     ndb = get_async_kb_ndb_client(
         zone=regional_api_config.zone_slug, kbid=kbid, user_token=auth._config.token
     )
+    auth.default_kb(kbid)
     await create_omelette_resource(ndb)
 
     yield kbid

--- a/nuclia_e2e/nuclia_e2e/tests/test_default_models.py
+++ b/nuclia_e2e/nuclia_e2e/tests/test_default_models.py
@@ -1,14 +1,10 @@
 from collections.abc import AsyncIterator
 from nuclia import sdk
 from nuclia.sdk.auth import AsyncNucliaAuth
-from nuclia_e2e.tests.conftest import ZoneConfig
 from nuclia_e2e.tests.utils import as_default_generative_model_for_kb
 from nuclia_e2e.tests.utils import clean_ask_test_tasks
 from nuclia_e2e.tests.utils import create_ask_agent
-from nuclia_e2e.tests.utils import create_omelette_resource
 from nuclia_e2e.tests.utils import DefaultModels
-from nuclia_e2e.utils import create_test_kb
-from nuclia_e2e.utils import delete_test_kb
 from nuclia_e2e.utils import get_async_kb_ndb_client
 
 import os
@@ -21,23 +17,6 @@ TEST_ENV = os.environ.get("TEST_ENV")
 # Global variable to know which tasks were created in this test
 # suite so we can clean them up properly on fixture teardown
 _tasks_to_delete: list[str] = []
-
-
-@pytest.fixture
-async def kb_id(regional_api_config: ZoneConfig, auth: AsyncNucliaAuth) -> AsyncIterator[str]:
-    unique_id = uuid.uuid4().hex
-    kb_slug = f"default-models-test-can-delete-{unique_id}"
-    kbid = await create_test_kb(regional_api_config, kb_slug)
-
-    ndb = get_async_kb_ndb_client(
-        zone=regional_api_config.zone_slug, kbid=kbid, user_token=auth._config.token
-    )
-    auth.default_kb(kbid)
-    await create_omelette_resource(ndb)
-
-    yield kbid
-
-    await delete_test_kb(regional_api_config, kbid, kb_slug)
 
 
 @pytest.fixture

--- a/nuclia_e2e/nuclia_e2e/tests/test_default_models.py
+++ b/nuclia_e2e/nuclia_e2e/tests/test_default_models.py
@@ -1,13 +1,10 @@
 from collections.abc import AsyncIterator
 from nuclia import sdk
 from nuclia.sdk.auth import AsyncNucliaAuth
-from nuclia_e2e.tests.conftest import ZoneConfig
 from nuclia_e2e.tests.utils import as_default_generative_model_for_kb
 from nuclia_e2e.tests.utils import clean_ask_test_tasks
 from nuclia_e2e.tests.utils import create_ask_agent
 from nuclia_e2e.tests.utils import DefaultModels
-from nuclia_e2e.utils import create_test_kb
-from nuclia_e2e.utils import delete_test_kb
 from nuclia_e2e.utils import get_async_kb_ndb_client
 
 import os
@@ -20,15 +17,6 @@ TEST_ENV = os.environ.get("TEST_ENV")
 # Global variable to know which tasks were created in this test
 # suite so we can clean them up properly on fixture teardown
 _tasks_to_delete: list[str] = []
-
-
-@pytest.fixture
-async def kb_id(regional_api_config: ZoneConfig) -> AsyncIterator[str]:
-    unique_id = uuid.uuid4().hex
-    kb_slug = f"custom-models-test-can-delete-{unique_id}"
-    kbid = await create_test_kb(regional_api_config, kb_slug)
-    yield kbid
-    await delete_test_kb(regional_api_config, kbid, kb_slug)
 
 
 @pytest.fixture

--- a/nuclia_e2e/nuclia_e2e/tests/test_default_models.py
+++ b/nuclia_e2e/nuclia_e2e/tests/test_default_models.py
@@ -46,7 +46,7 @@ async def default_model(
         found = next(
             mo for mo in default_list if (mo.get("default_model_id", "")).startswith(generative_model)
         )
-        return found["id"]
+        return f"{generative_model}/{found['id']}"
     except StopIteration:
         # Otherwise, configure a new default generative model config
         default_model_config_id = await default_models.add(

--- a/nuclia_e2e/nuclia_e2e/tests/test_default_models.py
+++ b/nuclia_e2e/nuclia_e2e/tests/test_default_models.py
@@ -46,17 +46,17 @@ async def default_model(
         found = next(
             mo for mo in default_list if (mo.get("default_model_id", "")).startswith(generative_model)
         )
-        return f"{generative_model}/{found['id']}"
+        config_id = found["id"]
     except StopIteration:
         # Otherwise, configure a new default generative model config
-        default_model_config_id = await default_models.add(
+        config_id = await default_models.add(
             generative_model=generative_model,
             model_data={
                 "default_model_id": generative_model,
                 "description": "Chatgpt4o with custom keys to be reused across all KBs of the account",
             },
         )
-        return f"{generative_model}/{default_model_config_id}"
+    return f"{generative_model}/{config_id}"
 
 
 @pytest.mark.asyncio_cooperative

--- a/nuclia_e2e/nuclia_e2e/tests/test_default_models.py
+++ b/nuclia_e2e/nuclia_e2e/tests/test_default_models.py
@@ -25,7 +25,7 @@ _tasks_to_delete: list[str] = []
 @pytest.fixture
 async def kb_id(regional_api_config: ZoneConfig) -> AsyncIterator[str]:
     unique_id = uuid.uuid4().hex
-    kb_slug = f"default-models-test-can-delete-{unique_id}"
+    kb_slug = f"custom-models-test-can-delete-{unique_id}"
     kbid = await create_test_kb(regional_api_config, kb_slug)
     yield kbid
     await delete_test_kb(regional_api_config, kbid, kb_slug)

--- a/nuclia_e2e/nuclia_e2e/tests/test_default_models.py
+++ b/nuclia_e2e/nuclia_e2e/tests/test_default_models.py
@@ -1,10 +1,14 @@
 from collections.abc import AsyncIterator
 from nuclia import sdk
 from nuclia.sdk.auth import AsyncNucliaAuth
+from nuclia_e2e.tests.conftest import ZoneConfig
 from nuclia_e2e.tests.utils import as_default_generative_model_for_kb
 from nuclia_e2e.tests.utils import clean_ask_test_tasks
 from nuclia_e2e.tests.utils import create_ask_agent
+from nuclia_e2e.tests.utils import create_omelette_resource
 from nuclia_e2e.tests.utils import DefaultModels
+from nuclia_e2e.utils import create_test_kb
+from nuclia_e2e.utils import delete_test_kb
 from nuclia_e2e.utils import get_async_kb_ndb_client
 
 import os
@@ -17,6 +21,22 @@ TEST_ENV = os.environ.get("TEST_ENV")
 # Global variable to know which tasks were created in this test
 # suite so we can clean them up properly on fixture teardown
 _tasks_to_delete: list[str] = []
+
+
+@pytest.fixture
+async def kb_id(regional_api_config: ZoneConfig, auth: AsyncNucliaAuth) -> AsyncIterator[str]:
+    unique_id = uuid.uuid4().hex
+    kb_slug = f"default-models-test-can-delete-{unique_id}"
+    kbid = await create_test_kb(regional_api_config, kb_slug)
+
+    ndb = get_async_kb_ndb_client(
+        zone=regional_api_config.zone_slug, kbid=kbid, user_token=auth._config.token
+    )
+    await create_omelette_resource(ndb)
+
+    yield kbid
+
+    await delete_test_kb(regional_api_config, kbid, kb_slug)
 
 
 @pytest.fixture

--- a/nuclia_e2e/nuclia_e2e/tests/test_default_models.py
+++ b/nuclia_e2e/nuclia_e2e/tests/test_default_models.py
@@ -32,6 +32,7 @@ async def kb_id(regional_api_config: ZoneConfig, auth: AsyncNucliaAuth) -> Async
     ndb = get_async_kb_ndb_client(
         zone=regional_api_config.zone_slug, kbid=kbid, user_token=auth._config.token
     )
+    auth.default_kb(kbid)
     await create_omelette_resource(ndb)
 
     yield kbid

--- a/nuclia_e2e/nuclia_e2e/tests/test_default_models.py
+++ b/nuclia_e2e/nuclia_e2e/tests/test_default_models.py
@@ -38,7 +38,7 @@ async def clean_tasks(kb_id: str, zone: str, auth: AsyncNucliaAuth) -> AsyncIter
 async def default_model(
     kb_id: str,
     default_models: DefaultModels,
-) -> AsyncIterator[str]:
+) -> str:
     # Make sure there are no default model configs
     await default_models.remove_all()
     assert len(await default_models.list()) == 0
@@ -55,11 +55,7 @@ async def default_model(
         },
     )
 
-    yield f"{generative_model}/{default_model_config_id}"
-
-    # Remove the default model config
-    # await default_models.remove_all()
-    # assert len(await default_models.list()) == 0
+    return f"{generative_model}/{default_model_config_id}"
 
 
 @pytest.mark.asyncio_cooperative

--- a/nuclia_e2e/nuclia_e2e/tests/test_default_models.py
+++ b/nuclia_e2e/nuclia_e2e/tests/test_default_models.py
@@ -97,7 +97,7 @@ async def _test_run_resource_agents(
     ndb = get_async_kb_ndb_client(zone=zone, kbid=kb_id, user_token=auth._config.token)
 
     # Configure an ingestion agent (aka task)
-    unique_id = str(uuid.uuid4())
+    unique_id = uuid.uuid4().hex
     agent_id = await create_ask_agent(
         kb_id,
         zone,

--- a/nuclia_e2e/nuclia_e2e/tests/test_default_models.py
+++ b/nuclia_e2e/nuclia_e2e/tests/test_default_models.py
@@ -1,8 +1,6 @@
 from collections.abc import AsyncIterator
 from nuclia import sdk
-from nuclia.data import get_async_auth
 from nuclia.sdk.auth import AsyncNucliaAuth
-from nuclia_e2e.tests.conftest import ZoneConfig
 from nuclia_e2e.tests.utils import as_default_generative_model_for_kb
 from nuclia_e2e.tests.utils import clean_ask_test_tasks
 from nuclia_e2e.tests.utils import create_ask_agent
@@ -19,42 +17,6 @@ TEST_ENV = os.environ.get("TEST_ENV")
 # Global variable to know which tasks were created in this test
 # suite so we can clean them up properly on fixture teardown
 _tasks_to_delete: list[str] = []
-
-
-@pytest.fixture
-async def kb_id(regional_api_config: ZoneConfig) -> str:
-    """
-    Fixture to provide the knowledge base ID for the tests.
-    """
-    assert regional_api_config.global_config is not None
-    return regional_api_config.permanent_kb_id
-
-
-@pytest.fixture
-async def zone(regional_api_config: ZoneConfig) -> str:
-    """
-    Fixture to provide the zone slug for the tests.
-    """
-    return regional_api_config.zone_slug
-
-
-@pytest.fixture
-def auth() -> AsyncNucliaAuth:
-    """
-    Fixture to provide the async Nuclia authentication object.
-    """
-    return get_async_auth()
-
-
-@pytest.fixture(autouse=True)
-async def account_id(regional_api_config: ZoneConfig, auth: AsyncNucliaAuth) -> str:
-    """
-    Fixture to provide the account slug for the tests.
-    """
-    assert regional_api_config.global_config is not None
-    account_slug = regional_api_config.global_config.permanent_account_slug
-    sdk.NucliaAccounts().default(account_slug)
-    return auth.get_account_id(account_slug)
 
 
 @pytest.fixture

--- a/nuclia_e2e/nuclia_e2e/tests/test_default_models.py
+++ b/nuclia_e2e/nuclia_e2e/tests/test_default_models.py
@@ -83,7 +83,9 @@ async def _test_generative(kb_id: str, zone: str, auth: AsyncNucliaAuth, generat
     extra_params = {}
     if generative_model:
         extra_params["generative_model"] = generative_model
-    answer = await sdk.AsyncNucliaSearch().ask(ndb=ndb, query="how to cook an omelette?", **extra_params)
+    answer = await sdk.AsyncNucliaSearch().ask(
+        ndb=ndb, query="how to cook an omelette? Answer in less than 200 words please.", **extra_params
+    )
     assert answer.answer is not None
     assert answer.status is not None
     assert answer.status == "success"

--- a/nuclia_e2e/nuclia_e2e/tests/test_default_models.py
+++ b/nuclia_e2e/nuclia_e2e/tests/test_default_models.py
@@ -58,8 +58,8 @@ async def default_model(
     yield f"{generative_model}/{default_model_config_id}"
 
     # Remove the default model config
-    await default_models.remove_all()
-    assert len(await default_models.list()) == 0
+    # await default_models.remove_all()
+    # assert len(await default_models.list()) == 0
 
 
 @pytest.mark.asyncio_cooperative

--- a/nuclia_e2e/nuclia_e2e/tests/test_default_models.py
+++ b/nuclia_e2e/nuclia_e2e/tests/test_default_models.py
@@ -64,7 +64,7 @@ async def default_model(
 
 @pytest.mark.asyncio_cooperative
 @pytest.mark.skipif(TEST_ENV != "stage", reason="This test is only for stage environment")
-async def test_default_model_config_works_for_generative_and_agents(
+async def test_default_model_works_for_generative_and_agents(
     request: pytest.FixtureRequest,
     kb_id: str,
     zone: str,
@@ -110,7 +110,7 @@ async def _test_run_resource_agents(
         question="Summarize the contents of the document in a single sentence.",
         generative_model=generative_model,
         generative_model_provider=generative_model_provider,
-        destination_field_prefix=f"summary-{unique_id}",
+        destination_field_prefix=f"summary_{unique_id}",
     )
 
     # Add to the list

--- a/nuclia_e2e/nuclia_e2e/tests/test_default_models.py
+++ b/nuclia_e2e/nuclia_e2e/tests/test_default_models.py
@@ -1,10 +1,13 @@
 from collections.abc import AsyncIterator
 from nuclia import sdk
 from nuclia.sdk.auth import AsyncNucliaAuth
+from nuclia_e2e.tests.conftest import ZoneConfig
 from nuclia_e2e.tests.utils import as_default_generative_model_for_kb
 from nuclia_e2e.tests.utils import clean_ask_test_tasks
 from nuclia_e2e.tests.utils import create_ask_agent
 from nuclia_e2e.tests.utils import DefaultModels
+from nuclia_e2e.utils import create_test_kb
+from nuclia_e2e.utils import delete_test_kb
 from nuclia_e2e.utils import get_async_kb_ndb_client
 
 import os
@@ -17,6 +20,15 @@ TEST_ENV = os.environ.get("TEST_ENV")
 # Global variable to know which tasks were created in this test
 # suite so we can clean them up properly on fixture teardown
 _tasks_to_delete: list[str] = []
+
+
+@pytest.fixture
+async def kb_id(regional_api_config: ZoneConfig) -> AsyncIterator[str]:
+    unique_id = uuid.uuid4().hex
+    kb_slug = f"custom-models-test-can-delete-{unique_id}"
+    kbid = await create_test_kb(regional_api_config, kb_slug)
+    yield kbid
+    await delete_test_kb(regional_api_config, kbid, kb_slug)
 
 
 @pytest.fixture

--- a/nuclia_e2e/nuclia_e2e/tests/test_default_models.py
+++ b/nuclia_e2e/nuclia_e2e/tests/test_default_models.py
@@ -68,14 +68,12 @@ async def test_default_model_works_for_generative_and_agents(
     default_model: str,
     clean_tasks: None,
 ):
-    await _test_generative(kb_id, zone, auth, generative_model=default_model)
-    await _test_run_resource_agents(
-        kb_id, zone, auth, generative_model=default_model, generative_model_provider="openai"
-    )
-
     async with as_default_generative_model_for_kb(kb_id, zone, auth, generative_model=default_model):
-        # Do not specify the generative model -- it should use the default one
         await _test_generative(kb_id, zone, auth, generative_model=None)
+        await _test_generative(kb_id, zone, auth, generative_model=default_model)
+        await _test_run_resource_agents(
+            kb_id, zone, auth, generative_model=default_model, generative_model_provider="openai"
+        )
 
 
 async def _test_generative(kb_id: str, zone: str, auth: AsyncNucliaAuth, generative_model: str | None = None):

--- a/nuclia_e2e/nuclia_e2e/tests/test_default_models.py
+++ b/nuclia_e2e/nuclia_e2e/tests/test_default_models.py
@@ -25,7 +25,7 @@ _tasks_to_delete: list[str] = []
 @pytest.fixture
 async def kb_id(regional_api_config: ZoneConfig) -> AsyncIterator[str]:
     unique_id = uuid.uuid4().hex
-    kb_slug = f"custom-models-test-can-delete-{unique_id}"
+    kb_slug = f"default-models-test-can-delete-{unique_id}"
     kbid = await create_test_kb(regional_api_config, kb_slug)
     yield kbid
     await delete_test_kb(regional_api_config, kbid, kb_slug)

--- a/nuclia_e2e/nuclia_e2e/tests/test_default_models.py
+++ b/nuclia_e2e/nuclia_e2e/tests/test_default_models.py
@@ -31,7 +31,9 @@ async def clean_tasks(kb_id: str, zone: str, auth: AsyncNucliaAuth) -> AsyncIter
 
     yield
 
-    await clean_ask_test_tasks(kb, ndb, to_delete=_tasks_to_delete)
+    if _tasks_to_delete:
+        await clean_ask_test_tasks(kb, ndb, to_delete=_tasks_to_delete)
+        _tasks_to_delete.clear()
 
 
 @pytest.fixture

--- a/nuclia_e2e/nuclia_e2e/tests/test_kb_backup.py
+++ b/nuclia_e2e/nuclia_e2e/tests/test_kb_backup.py
@@ -3,6 +3,7 @@ from nuclia import sdk
 from nuclia.data import get_auth
 from nuclia.sdk.kbs import AsyncNucliaKBS
 from nuclia.sdk.search import AsyncNucliaSearch
+from nuclia_e2e.nuclia_e2e.tests.utils import as_default_generative_model_for_kb
 from nuclia_e2e.tests.conftest import ZoneConfig
 from nuclia_e2e.utils import get_async_kb_ndb_client
 from nuclia_e2e.utils import get_kbid_from_slug
@@ -35,9 +36,10 @@ async def test_kb_backup(request: pytest.FixtureRequest, regional_api_config: Zo
     await sdk.AsyncNucliaKB().extract_strategies.add(ndb=ndb, config={"name": "strategy1", "vllm_config": {}})
 
     # Create Backup
-    backup_create = await sdk.AsyncNucliaBackup().create(
-        backup=BackupCreate(kb_id=uuid.UUID(kb_id)), zone=zone
-    )
+    async with as_default_generative_model_for_kb(kb_id, zone, auth, generative_model="chatgpt4o"):
+        backup_create = await sdk.AsyncNucliaBackup().create(
+            backup=BackupCreate(kb_id=uuid.UUID(kb_id)), zone=zone
+        )
 
     # Wait till backup is finished
     async def check_backup_finished() -> tuple[bool, BackupResponse]:

--- a/nuclia_e2e/nuclia_e2e/tests/test_kb_backup.py
+++ b/nuclia_e2e/nuclia_e2e/tests/test_kb_backup.py
@@ -3,8 +3,8 @@ from nuclia import sdk
 from nuclia.data import get_auth
 from nuclia.sdk.kbs import AsyncNucliaKBS
 from nuclia.sdk.search import AsyncNucliaSearch
-from nuclia_e2e.nuclia_e2e.tests.utils import as_default_generative_model_for_kb
 from nuclia_e2e.tests.conftest import ZoneConfig
+from nuclia_e2e.tests.utils import as_default_generative_model_for_kb
 from nuclia_e2e.utils import get_async_kb_ndb_client
 from nuclia_e2e.utils import get_kbid_from_slug
 from nuclia_e2e.utils import wait_for

--- a/nuclia_e2e/nuclia_e2e/tests/test_kb_backup.py
+++ b/nuclia_e2e/nuclia_e2e/tests/test_kb_backup.py
@@ -1,6 +1,6 @@
 from collections.abc import Callable
 from nuclia import sdk
-from nuclia.data import get_auth
+from nuclia.data import get_async_auth
 from nuclia.sdk.kbs import AsyncNucliaKBS
 from nuclia.sdk.search import AsyncNucliaSearch
 from nuclia_e2e.tests.conftest import ZoneConfig
@@ -31,7 +31,7 @@ async def test_kb_backup(request: pytest.FixtureRequest, regional_api_config: Zo
     sdk.NucliaAccounts().default(account_slug)
 
     # Create an extract configuration for the source KB
-    auth = get_auth()
+    auth = get_async_auth()
     ndb = get_async_kb_ndb_client(zone=zone, kbid=kb_id, user_token=auth._config.token)
     await sdk.AsyncNucliaKB().extract_strategies.add(ndb=ndb, config={"name": "strategy1", "vllm_config": {}})
 
@@ -70,7 +70,7 @@ async def test_kb_backup(request: pytest.FixtureRequest, regional_api_config: Zo
     assert kb_get is not None
 
     # Wait restore is completed
-    auth = get_auth()
+    auth = get_async_auth()
     ndb = get_async_kb_ndb_client(zone=zone, kbid=new_kb.id, user_token=auth._config.token)
     search = AsyncNucliaSearch()
 

--- a/nuclia_e2e/nuclia_e2e/tests/test_kb_backup.py
+++ b/nuclia_e2e/nuclia_e2e/tests/test_kb_backup.py
@@ -41,15 +41,15 @@ async def test_kb_backup(request: pytest.FixtureRequest, regional_api_config: Zo
             backup=BackupCreate(kb_id=uuid.UUID(kb_id)), zone=zone
         )
 
-    # Wait till backup is finished
-    async def check_backup_finished() -> tuple[bool, BackupResponse]:
-        backups = await sdk.AsyncNucliaBackup().list(zone=zone)
-        backup_list = [b for b in backups if b.id == backup_create.id]
-        assert len(backup_list) == 1
-        backup_object = backup_list[0]
-        return backup_object.finished_at is not None, backup_object
+        # Wait till backup is finished
+        async def check_backup_finished() -> tuple[bool, BackupResponse]:
+            backups = await sdk.AsyncNucliaBackup().list(zone=zone)
+            backup_list = [b for b in backups if b.id == backup_create.id]
+            assert len(backup_list) == 1
+            backup_object = backup_list[0]
+            return backup_object.finished_at is not None, backup_object
 
-    await wait_for(condition=check_backup_finished, max_wait=180, interval=10)
+        await wait_for(condition=check_backup_finished, max_wait=180, interval=10)
 
     new_kb_slug = f"{regional_api_config.test_kb_slug}-test_kb_backup"
 

--- a/nuclia_e2e/nuclia_e2e/tests/utils.py
+++ b/nuclia_e2e/nuclia_e2e/tests/utils.py
@@ -28,7 +28,8 @@ locks: dict[str, Lock] = {}
 
 @contextlib.asynccontextmanager
 async def lock(key: str) -> AsyncIterator[Lock]:
-    async with locks.setdefault(key, Lock()):
+    _lock = locks.setdefault(key, Lock())
+    async with _lock():
         yield
 
 

--- a/nuclia_e2e/nuclia_e2e/tests/utils.py
+++ b/nuclia_e2e/nuclia_e2e/tests/utils.py
@@ -66,6 +66,8 @@ async def as_default_generative_model_for_kb(
     """
     Context manager that sets the KB's default generative model and restores the previous one upon exit.
     """
+    # A lock is needed because some tests are reusing the same kb and changing the learning config.
+    # As we are running the tests concurrently, otherwise they mess up each other.
     async with lock(f"learning-config-{kb_id}"):
         ndb = get_async_kb_ndb_client(zone=zone, kbid=kb_id, user_token=auth._config.token)
         kb = sdk.AsyncNucliaKB()

--- a/nuclia_e2e/nuclia_e2e/tests/utils.py
+++ b/nuclia_e2e/nuclia_e2e/tests/utils.py
@@ -243,7 +243,7 @@ class DefaultModels:
         model_id = response["id"]
         return model_id
 
-    async def list(self) -> list:
+    async def list(self) -> list[dict[str, str]]:
         path = get_regional_url(self.zone, f"/api/v1/account/{self.account_id}/default_models")
         models = await root_request(self.auth, "GET", path)
         assert models is not None

--- a/nuclia_e2e/nuclia_e2e/tests/utils.py
+++ b/nuclia_e2e/nuclia_e2e/tests/utils.py
@@ -76,9 +76,11 @@ async def as_default_generative_model_for_kb(
         if previous_generative_model != generative_model:
             print(f"Setting default model for kbid={kb_id} model={generative_model}")
             await kb.update_configuration(ndb=ndb, generative_model=generative_model)
-            try:
-                yield
-            finally:
+        try:
+            yield
+        finally:
+            if previous_generative_model != generative_model:
+                print(f"Resetting default model for kbid={kb_id} model={previous_generative_model}")
                 await kb.update_configuration(ndb=ndb, generative_model=previous_generative_model)
 
 

--- a/nuclia_e2e/nuclia_e2e/tests/utils.py
+++ b/nuclia_e2e/nuclia_e2e/tests/utils.py
@@ -1,0 +1,76 @@
+from collections.abc import AsyncIterator
+from nuclia import sdk
+from nuclia.lib.kb import AsyncNucliaDBClient
+from nuclia.sdk.auth import AsyncNucliaAuth
+from nuclia_e2e.utils import get_async_kb_ndb_client
+from nucliadb_sdk.v2.exceptions import NotFoundError
+
+import contextlib
+import os
+
+
+async def root_request(
+    auth: AsyncNucliaAuth,
+    method: str,
+    path: str,
+    data: dict | None = None,
+    headers: dict | None = None,
+) -> dict | None:
+    """
+    Make a request to the API with root credentials. This is not currently supported by the SDK,
+    so we need to do it manually.
+    """
+    headers = headers or {}
+    stage_root_pat_token = os.environ["STAGE_ROOT_PAT_TOKEN"]
+    headers["Authorization"] = f"Bearer {stage_root_pat_token}"
+    resp = await auth.client.request(
+        method,
+        path,
+        json=data,
+        headers=headers,
+    )
+    resp.raise_for_status()
+    if resp.status_code == 204:
+        return None
+    return resp.json()
+
+
+@contextlib.asynccontextmanager
+async def as_kb_default_generative_model(
+    kb_id: str, zone: str, auth: AsyncNucliaAuth, generative_model: str
+) -> AsyncIterator[None]:
+    ndb = get_async_kb_ndb_client(zone=zone, kbid=kb_id, user_token=auth._config.token)
+    kb = sdk.AsyncNucliaKB()
+    previous = await kb.get_configuration(ndb=ndb)
+    previous_generative_model = previous["generative_model"]
+    await kb.update_configuration(ndb=ndb, generative_model=generative_model)
+    try:
+        yield
+    finally:
+        await kb.update_configuration(ndb=ndb, generative_model=previous_generative_model)
+
+
+async def has_generated_field(
+    ndb: AsyncNucliaDBClient,
+    kb: sdk.AsyncNucliaKB,
+    resource_slug: str,
+    expected_field_id_prefix: str,
+) -> bool:
+    """
+    Check if the resource has the extracted text for the generated field.
+    """
+    try:
+        res = await kb.resource.get(slug=resource_slug, show=["values", "extracted"], ndb=ndb)
+    except NotFoundError:
+        # some resource may still be missing from nucliadb, let's wait more
+        return False
+    try:
+        for fid, data in res.data.texts.items():
+            if fid.startswith(expected_field_id_prefix) and data.extracted.text.text is not None:
+                return True
+    except (TypeError, AttributeError):
+        # If the resource does not have the expected structure, let's wait more
+        return False
+    else:
+        # If we reach here, it means the field was not found
+        return False

--- a/nuclia_e2e/nuclia_e2e/tests/utils.py
+++ b/nuclia_e2e/nuclia_e2e/tests/utils.py
@@ -104,7 +104,7 @@ async def create_omelette_resource(ndb: AsyncNucliaDBClient):
     max_wait_seconds: int = 300
     start = time.time()
     while (time.time() - start) < max_wait_seconds:
-        resource = await kb.resource.get(slug=slug)
+        resource = await kb.resource.get(slug=slug, show=["values"])
         status = resource.data.texts["omelette"].status
         if status == "PROCESSED":
             break

--- a/nuclia_e2e/nuclia_e2e/tests/utils.py
+++ b/nuclia_e2e/nuclia_e2e/tests/utils.py
@@ -103,13 +103,16 @@ async def create_omelette_resource(ndb: AsyncNucliaDBClient):
     )
     max_wait_seconds: int = 300
     start = time.time()
+    processed = False
     while (time.time() - start) < max_wait_seconds:
         resource = await kb.resource.get(slug=slug, show=["values"])
         status = resource.data.texts["omelette"].status
         if status == "PROCESSED":
+            processed = True
             break
         print(status)
         await asyncio.sleep(5)
+    assert processed, "Resource not processed in time"
 
 
 async def create_ask_agent(

--- a/nuclia_e2e/nuclia_e2e/tests/utils.py
+++ b/nuclia_e2e/nuclia_e2e/tests/utils.py
@@ -73,7 +73,7 @@ async def as_default_generative_model_for_kb(
     async with lock(f"learning-config-{kb_id}"):
         previous = await kb.get_configuration(ndb=ndb)
         previous_generative_model = previous["generative_model"]
-        if previous_generative_model == generative_model:
+        if previous_generative_model != generative_model:
             print(f"Setting default model for kbid={kb_id} model={generative_model}")
             await kb.update_configuration(ndb=ndb, generative_model=generative_model)
             try:

--- a/nuclia_e2e/nuclia_e2e/utils.py
+++ b/nuclia_e2e/nuclia_e2e/utils.py
@@ -53,7 +53,7 @@ async def create_test_kb(regional_api_config, kb_slug, logger: Logger = print) -
     return kbid
 
 
-async def delete_test_kb(regional_api_config, kbid, kb_slug, logger):
+async def delete_test_kb(regional_api_config, kbid, kb_slug, logger: Logger = print):
     kbs = AsyncNucliaKBS()
     logger("Deleting kb {kbid}")
     await kbs.delete(zone=regional_api_config.zone_slug, id=kbid)

--- a/nuclia_e2e/nuclia_e2e/utils.py
+++ b/nuclia_e2e/nuclia_e2e/utils.py
@@ -53,7 +53,7 @@ async def create_test_kb(regional_api_config, kb_slug, logger: Logger = print) -
     return kbid
 
 
-async def delete_test_kb(regional_api_config, kbid, kb_slug, logger: Logger = print):
+async def delete_test_kb(regional_api_config, kbid, kb_slug, logger):
     kbs = AsyncNucliaKBS()
     logger("Deleting kb {kbid}")
     await kbs.delete(zone=regional_api_config.zone_slug, id=kbid)

--- a/nuclia_e2e/nuclia_e2e/utils.py
+++ b/nuclia_e2e/nuclia_e2e/utils.py
@@ -53,7 +53,7 @@ async def create_test_kb(regional_api_config, kb_slug, logger: Logger = print) -
     return kbid
 
 
-async def delete_test_kb(regional_api_config, kbid, kb_slug, logger):
+async def delete_test_kb(regional_api_config, kbid, kb_slug, logger=print):
     kbs = AsyncNucliaKBS()
     logger("Deleting kb {kbid}")
     await kbs.delete(zone=regional_api_config.zone_slug, id=kbid)


### PR DESCRIPTION
- Added tests for account default models
- Unified a bunch of utils and fixtures in tests
- Changed the way we're testing agents to use the run-agents endpoint: much less flaky (hopefully)
- Added lock for setting default kb generative model to avoid race conditions