### PR TITLE
Add new region for testing

### DIFF
--- a/.github/workflows/run-e2e-nuclia-prod.yml
+++ b/.github/workflows/run-e2e-nuclia-prod.yml
@@ -58,7 +58,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        zone: [gke-prod-1, aws-us-east-2-1, aws-il-central-1-1, aws-eu-central-1-1]
+        zone: [gke-prod-1, aws-us-east-2-1, aws-il-central-1-1, aws-eu-central-1-1, aws-me-central-1-1]
         shard_index: [0, 1, 2]  # Running tests in 3 parallel shards
     needs:
       - build-virtual-env
@@ -84,6 +84,7 @@ jobs:
           PROD_AWS_US_EAST_2_1_NUA: ${{ secrets.PROD_AWS_US_EAST_2_1_NUA }}
           PROD_AWS_IL_CENTRAL_1_1_NUA: ${{ secrets.PROD_AWS_IL_CENTRAL_1_1_NUA }}
           PROD_AWS_EU_CENTRAL_1_1_NUA: ${{ secrets.PROD_AWS_EU_CENTRAL_1_1_NUA }}
+          PROD_AWS_ME_CENTRAL_1_1_NUA: ${{ secrets.PROD_AWS_ME_CENTRAL_1_1_NUA }}
           TEST_GMAIL_APP_PASSWORD: ${{ secrets.TEST_GMAIL_APP_PASSWORD }}
           GRAFANA_URL: ${{ secrets.GRAFANA_URL }}
           TEST_ZONES: ${{ matrix.zone }}

--- a/nuclia_e2e/nuclia_e2e/tests/conftest.py
+++ b/nuclia_e2e/nuclia_e2e/tests/conftest.py
@@ -151,6 +151,13 @@ CLUSTERS_CONFIG = {
                 permanent_kb_slug="pre-existing-kb",
                 permanent_nua_key=safe_get_prod_env("PROD_AWS_EU_CENTRAL_1_1_NUA"),
             ),
+            ZoneConfig(
+                name="aws-me-central-1-1",
+                zone_slug="aws-me-central-1-1",
+                test_kb_slug="nuclia-e2e-live-aws-me-central-1-1",
+                permanent_kb_slug="pre-existing-kb",
+                permanent_nua_key=safe_get_prod_env("PROD_AWS_ME_CENTRAL_1_1_NUA"),
+            ),
         ],
     ),
     "stage": ClusterConfig(


### PR DESCRIPTION
This pull request adds support for a new AWS region (`aws-me-central-1-1`) to the end-to-end test infrastructure. The changes ensure that tests are run in this new region, with the necessary configuration and secrets included.

**E2E Test Infrastructure Expansion:**

* Added `aws-me-central-1-1` to the test zones matrix in the GitHub Actions workflow, enabling tests to run in the new region.
* Added the corresponding secret (`PROD_AWS_ME_CENTRAL_1_1_NUA`) to the workflow environment variables for authentication in the new region.
* Updated the `ClusterConfig` in `conftest.py` to include a `ZoneConfig` for `aws-me-central-1-1`, ensuring the test suite is aware of and can use this new zone.