### PR TITLE
Fix PAT stage for prod exevutions

### DIFF
--- a/nuclia_e2e/nuclia_e2e/tests/utils.py
+++ b/nuclia_e2e/nuclia_e2e/tests/utils.py
@@ -50,7 +50,7 @@ async def root_request(
     so we need to do it manually.
     """
     headers = headers or {}
-    stage_root_pat_token = os.environ["STAGE_ROOT_PAT_TOKEN"]
+    stage_root_pat_token = os.environ.get("STAGE_ROOT_PAT_TOKEN", "")
     headers["Authorization"] = f"Bearer {stage_root_pat_token}"
     resp = await auth.client.request(
         method,


### PR DESCRIPTION
This pull request makes a small improvement to the `root_request` utility function by making the retrieval of the `STAGE_ROOT_PAT_TOKEN` environment variable more robust. Instead of raising an error if the variable is missing, it now defaults to an empty string, preventing potential crashes during testing.