### PR TITLE
Add defailt value

### DIFF
--- a/nuclia_e2e/nuclia_e2e/tests/utils.py
+++ b/nuclia_e2e/nuclia_e2e/tests/utils.py
@@ -50,7 +50,7 @@ async def root_request(
     so we need to do it manually.
     """
     headers = headers or {}
-    stage_root_pat_token = os.environ.get("STAGE_ROOT_PAT_TOKEN", "")
+    stage_root_pat_token = os.environ.get("STAGE_ROOT_PAT_TOKEN", "skip-auth")
     headers["Authorization"] = f"Bearer {stage_root_pat_token}"
     resp = await auth.client.request(
         method,


### PR DESCRIPTION
This pull request makes a minor adjustment to the `root_request` utility function to improve its behavior when the `STAGE_ROOT_PAT_TOKEN` environment variable is not set.

- Changed the default value for `STAGE_ROOT_PAT_TOKEN` from an empty string to `"skip-auth"` in `nuclia_e2e/tests/utils.py`, ensuring a more explicit fallback for authorization in test environments.