### PR TITLE
Use global config to retrieve root pat token

### DIFF
--- a/nuclia_e2e/nuclia_e2e/tests/test_account_models.py
+++ b/nuclia_e2e/nuclia_e2e/tests/test_account_models.py
@@ -13,9 +13,8 @@ TEST_ENV = os.environ.get("TEST_ENV")
 
 
 @pytest.fixture
-async def custom_models(auth: AsyncNucliaAuth, zone: str, account_id: str) -> CustomModels:
-    return CustomModels(auth, zone, account_id)
-
+async def custom_models(auth: AsyncNucliaAuth, zone: str, account_id: str, global_api_config) -> CustomModels:
+    return CustomModels(auth, zone, account_id, global_api_config.root_pat_token)
 
 @pytest.fixture
 async def custom_model(kb_id: str, custom_models: CustomModels) -> str:

--- a/nuclia_e2e/nuclia_e2e/tests/test_account_models.py
+++ b/nuclia_e2e/nuclia_e2e/tests/test_account_models.py
@@ -13,8 +13,11 @@ TEST_ENV = os.environ.get("TEST_ENV")
 
 
 @pytest.fixture
-async def custom_models(auth: AsyncNucliaAuth, zone: str, account_id: str, global_api_config) -> CustomModels:
+async def custom_models(
+    auth: AsyncNucliaAuth, zone: str, account_id: str, global_api_config
+) -> CustomModels:
     return CustomModels(auth, zone, account_id, global_api_config.root_pat_token)
+
 
 @pytest.fixture
 async def custom_model(kb_id: str, custom_models: CustomModels) -> str:
@@ -51,8 +54,10 @@ async def custom_model(kb_id: str, custom_models: CustomModels) -> str:
 
 
 @pytest.fixture
-async def default_models(auth: AsyncNucliaAuth, zone: str, account_id: str) -> DefaultModels:
-    return DefaultModels(auth, zone, account_id)
+async def default_models(
+    auth: AsyncNucliaAuth, zone: str, account_id: str, global_api_config
+) -> DefaultModels:
+    return DefaultModels(auth, zone, account_id, global_api_config.root_pat_token)
 
 
 @pytest.fixture
@@ -65,7 +70,9 @@ async def default_model(
     try:
         # If there is already one, return it
         found = next(
-            mo for mo in default_list if (mo.get("default_model_id", "")).startswith(generative_model)
+            mo
+            for mo in default_list
+            if (mo.get("default_model_id", "")).startswith(generative_model)
         )
         config_id = found["id"]
     except StopIteration:
@@ -105,7 +112,9 @@ async def test_account_models(
     if TEST_ENV == "stage":
         print("Running default and custom model tests in stage environment")
         # Default model tests
-        async with as_default_generative_model_for_kb(kb_id, zone, auth, generative_model=default_model):
+        async with as_default_generative_model_for_kb(
+            kb_id, zone, auth, generative_model=default_model
+        ):
             await run_generative_test(kb_id, zone, auth, generative_model=None)
             await run_generative_test(kb_id, zone, auth, generative_model=default_model)
             await run_resource_agents_test(
@@ -141,7 +150,10 @@ async def test_account_models(
         ):
             await run_generative_test(kb_id, zone, auth, generative_model=None)
             await run_generative_test(
-                kb_id, zone, auth, generative_model=default_model_with_bedrock_assume_role
+                kb_id,
+                zone,
+                auth,
+                generative_model=default_model_with_bedrock_assume_role,
             )
             await run_resource_agents_test(
                 kb_id,

--- a/nuclia_e2e/nuclia_e2e/tests/test_account_models.py
+++ b/nuclia_e2e/nuclia_e2e/tests/test_account_models.py
@@ -13,9 +13,7 @@ TEST_ENV = os.environ.get("TEST_ENV")
 
 
 @pytest.fixture
-async def custom_models(
-    auth: AsyncNucliaAuth, zone: str, account_id: str, global_api_config
-) -> CustomModels:
+async def custom_models(auth: AsyncNucliaAuth, zone: str, account_id: str, global_api_config) -> CustomModels:
     return CustomModels(auth, zone, account_id, global_api_config.root_pat_token)
 
 
@@ -70,9 +68,7 @@ async def default_model(
     try:
         # If there is already one, return it
         found = next(
-            mo
-            for mo in default_list
-            if (mo.get("default_model_id", "")).startswith(generative_model)
+            mo for mo in default_list if (mo.get("default_model_id", "")).startswith(generative_model)
         )
         config_id = found["id"]
     except StopIteration:
@@ -112,9 +108,7 @@ async def test_account_models(
     if TEST_ENV == "stage":
         print("Running default and custom model tests in stage environment")
         # Default model tests
-        async with as_default_generative_model_for_kb(
-            kb_id, zone, auth, generative_model=default_model
-        ):
+        async with as_default_generative_model_for_kb(kb_id, zone, auth, generative_model=default_model):
             await run_generative_test(kb_id, zone, auth, generative_model=None)
             await run_generative_test(kb_id, zone, auth, generative_model=default_model)
             await run_resource_agents_test(

--- a/nuclia_e2e/nuclia_e2e/tests/utils.py
+++ b/nuclia_e2e/nuclia_e2e/tests/utils.py
@@ -19,7 +19,6 @@ from pytest_asyncio_cooperative import Lock  # type: ignore[import-untyped]
 
 import asyncio
 import contextlib
-import os
 import time
 import traceback
 import uuid

--- a/nuclia_e2e/nuclia_e2e/tests/utils.py
+++ b/nuclia_e2e/nuclia_e2e/tests/utils.py
@@ -203,10 +203,12 @@ class CustomModels:
         auth: AsyncNucliaAuth,
         zone: str,
         account_id: str,
+        root_pat_token: str,
     ):
         self.auth = auth
         self.zone = zone
         self.account_id = account_id
+        self.root_pat_token = root_pat_token
 
     async def add(
         self,

--- a/nuclia_e2e/nuclia_e2e/tests/utils.py
+++ b/nuclia_e2e/nuclia_e2e/tests/utils.py
@@ -42,6 +42,7 @@ async def root_request(
     auth: AsyncNucliaAuth,
     method: str,
     path: str,
+    root_pat_token: str,
     data: dict | None = None,
     headers: dict | None = None,
 ) -> dict | None:
@@ -50,8 +51,7 @@ async def root_request(
     so we need to do it manually.
     """
     headers = headers or {}
-    stage_root_pat_token = os.environ.get("STAGE_ROOT_PAT_TOKEN", "skip-auth")
-    headers["Authorization"] = f"Bearer {stage_root_pat_token}"
+    headers["Authorization"] = f"Bearer {root_pat_token}"
     resp = await auth.client.request(
         method,
         path,

--- a/nuclia_e2e/nuclia_e2e/tests/utils.py
+++ b/nuclia_e2e/nuclia_e2e/tests/utils.py
@@ -84,12 +84,8 @@ async def as_default_generative_model_for_kb(
             yield
         finally:
             if previous_generative_model != generative_model:
-                print(
-                    f"Resetting default model for kbid={kb_id} model={previous_generative_model}"
-                )
-                await kb.update_configuration(
-                    ndb=ndb, generative_model=previous_generative_model
-                )
+                print(f"Resetting default model for kbid={kb_id} model={previous_generative_model}")
+                await kb.update_configuration(ndb=ndb, generative_model=previous_generative_model)
 
 
 async def has_generated_field(
@@ -102,18 +98,13 @@ async def has_generated_field(
     Check if the resource has the extracted text for the generated field.
     """
     try:
-        res = await kb.resource.get(
-            slug=resource_slug, show=["values", "extracted"], ndb=ndb
-        )
+        res = await kb.resource.get(slug=resource_slug, show=["values", "extracted"], ndb=ndb)
     except NotFoundError:
         # some resource may still be missing from nucliadb, let's wait more
         return False
     try:
         for fid, data in res.data.texts.items():
-            if (
-                fid.startswith(expected_field_id_prefix)
-                and data.extracted.text.text is not None
-            ):
+            if fid.startswith(expected_field_id_prefix) and data.extracted.text.text is not None:
                 return True
     except (TypeError, AttributeError):
         # If the resource does not have the expected structure, let's wait more
@@ -129,11 +120,7 @@ async def create_omelette_resource(ndb: AsyncNucliaDBClient):
     await kb.resource.create(
         ndb=ndb,
         slug=slug,
-        texts={
-            "omelette": TextField(
-                body="To cook an omelette, you need to crack the egg."
-            )
-        },
+        texts={"omelette": TextField(body="To cook an omelette, you need to crack the egg.")},
     )
     max_wait_seconds: int = 300
     start = time.time()
@@ -184,9 +171,7 @@ async def create_ask_agent(
     return task_id
 
 
-async def clean_ask_test_tasks(
-    kb: sdk.AsyncNucliaKB, ndb: AsyncNucliaDBClient, to_delete: list[str]
-):
+async def clean_ask_test_tasks(kb: sdk.AsyncNucliaKB, ndb: AsyncNucliaDBClient, to_delete: list[str]):
     tasks = await kb.task.list(ndb=ndb)
     for task in tasks.running + tasks.done + tasks.configs:
         if task.id in to_delete:
@@ -217,20 +202,14 @@ class CustomModels:
     ):
         # Add model to the account
         path = get_regional_url(self.zone, f"/api/v1/account/{self.account_id}/models")
-        response = await root_request(
-            self.auth, "POST", path, self.root_pat_token, data=model_data
-        )
+        response = await root_request(self.auth, "POST", path, self.root_pat_token, data=model_data)
         assert response is not None
         model_id = response["id"]
 
         # Add model to the kbs
         for kb in kbs:
-            path = get_regional_url(
-                self.zone, f"/api/v1/account/{self.account_id}/models/{kb}"
-            )
-            await root_request(
-                self.auth, "POST", path, self.root_pat_token, data={"id": model_id}
-            )
+            path = get_regional_url(self.zone, f"/api/v1/account/{self.account_id}/models/{kb}")
+            await root_request(self.auth, "POST", path, self.root_pat_token, data={"id": model_id})
 
     async def list(self) -> list:
         path = get_regional_url(self.zone, f"/api/v1/account/{self.account_id}/models")
@@ -240,9 +219,7 @@ class CustomModels:
         return models
 
     async def delete(self, model_id: str) -> None:
-        path = get_regional_url(
-            self.zone, f"/api/v1/account/{self.account_id}/model/{model_id}"
-        )
+        path = get_regional_url(self.zone, f"/api/v1/account/{self.account_id}/model/{model_id}")
         await root_request(self.auth, "DELETE", path, self.root_pat_token)
 
     async def remove_all(self) -> None:
@@ -272,29 +249,21 @@ class DefaultModels:
         if "default_model_id" not in model_data:
             model_data["default_model_id"] = generative_model
         # Add model to the account
-        path = get_regional_url(
-            self.zone, f"/api/v1/account/{self.account_id}/default_models"
-        )
-        response = await root_request(
-            self.auth, "POST", path, self.root_pat_token, data=model_data
-        )
+        path = get_regional_url(self.zone, f"/api/v1/account/{self.account_id}/default_models")
+        response = await root_request(self.auth, "POST", path, self.root_pat_token, data=model_data)
         assert response is not None
         model_id = response["id"]
         return model_id
 
     async def list(self) -> list[dict[str, str]]:
-        path = get_regional_url(
-            self.zone, f"/api/v1/account/{self.account_id}/default_models"
-        )
+        path = get_regional_url(self.zone, f"/api/v1/account/{self.account_id}/default_models")
         models = await root_request(self.auth, "GET", path, self.root_pat_token)
         assert models is not None
         assert isinstance(models, list)
         return models
 
     async def delete(self, model_id: str) -> None:
-        path = get_regional_url(
-            self.zone, f"/api/v1/account/{self.account_id}/default_model/{model_id}"
-        )
+        path = get_regional_url(self.zone, f"/api/v1/account/{self.account_id}/default_model/{model_id}")
         await root_request(self.auth, "DELETE", path, self.root_pat_token)
 
     async def remove_all(self) -> None:


### PR DESCRIPTION
This pull request updates how the root Personal Access Token (PAT) is handled in test utilities and fixtures, making token usage more explicit and configurable. The most important changes are:

**Test utilities and authentication:**

* The `root_request` function in `utils.py` now requires a `root_pat_token` argument instead of fetching the token from the `STAGE_ROOT_PAT_TOKEN` environment variable, making token usage more explicit and controllable. [[1]](diffhunk://#diff-c11006a71fab65fbaa6cd2d4c1e823d8a68ee78358420aa508e76585a297a558R45) [[2]](diffhunk://#diff-c11006a71fab65fbaa6cd2d4c1e823d8a68ee78358420aa508e76585a297a558L53-R54)

**Test fixtures:**

* The `custom_models` fixture in `test_account_models.py` is updated to accept and pass the `root_pat_token` from `global_api_config`, ensuring tests use the correct authentication token.