### PR TITLE
Add minimal configuration for e2e repo

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": [
+        "config:recommended",
+        ":dependencyDashboard"
+    ],
+    "rebaseWhen": "never",
+    "lockFileMaintenance": {
+        "enabled": true
+    },
+    "assignees": [
+        "operramon",
+        "ebrehault",
+        "drf7",
+        "sunbit",
+        "lferran",
+        "jotare",
+        "rastut"
+    ],
+    "pep621": {
+        "enabled": true
+    }
+}


### PR DESCRIPTION
This pull request adds a new configuration file for Renovate, which will help automate dependency updates and maintenance for the project.

Renovate configuration setup:

* Added `.github/renovate.json` to enable Renovate bot, specifying recommended settings, dependency dashboard, and lock file maintenance.
* Set `rebaseWhen` to `"never"` to control update behavior, and enabled PEP 621 support for Python projects.
* Assigned specific team members as default assignees for Renovate-created pull requests.