### PR TITLE
Change package manager

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -17,7 +17,7 @@
         "jotare",
         "rastut"
     ],
-    "pep621": {
+    "pep723": {
         "enabled": true
     }
 }


### PR DESCRIPTION
This pull request makes a small configuration change to the `.github/renovate.json` file, updating the enabled Python packaging standard from PEP 621 to PEP 723. This ensures Renovate will use the newer standard for dependency management.

* Updated the configuration key from `"pep621"` to `"pep723"` and enabled it in `.github/renovate.json`.