### PR TITLE
renovate: Enable lockfile management

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,13 +1,13 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "lockFileMaintenance": {
+        "enabled": true
+    },
     "extends": [
         "config:recommended",
         ":dependencyDashboard"
     ],
     "rebaseWhen": "never",
-    "lockFileMaintenance": {
-        "enabled": true
-    },
     "assignees": [
         "operramon",
         "ebrehault",
@@ -17,7 +17,10 @@
         "jotare",
         "rastut"
     ],
-    "pep723": {
+    "pep621": {
         "enabled": true
+    },
+    "poetry": {
+        "enabled": false
     }
 }


### PR DESCRIPTION
This pull request updates the Renovate configuration to improve dependency management and clarify configuration options. The main changes involve renaming and updating configuration keys for Python packaging standards and adjusting lock file maintenance settings.

**Dependency management configuration:**

* Renamed the configuration key from `pep723` to `pep621` and enabled it, aligning with the correct Python packaging standard.
* Added a new configuration for `poetry` and explicitly disabled it to prevent Renovate from managing Poetry dependencies.

**Lock file maintenance:**

* Moved the `lockFileMaintenance` block to the correct position in the JSON file, but its settings remain unchanged.