### PR TITLE
Bump slack api action + fix workflow_dispatch

### DIFF
--- a/.github/workflows/run-e2e-dev.yml
+++ b/.github/workflows/run-e2e-dev.yml
@@ -2,8 +2,6 @@ name: run-e2e-dev
 run-name: Running Cypress e2e tests on Dev
 on:
   workflow_dispatch:
-    branches:
-      - main
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true
@@ -57,13 +55,12 @@ jobs:
           if-no-files-found: ignore # 'warn' or 'error' are also available, defaults to `warn`
       - name: Slack notification
         id: slack
-        uses: slackapi/slack-github-action@v1.25.0
+        uses: slackapi/slack-github-action@v2.1.1
         if: ${{ failure() && steps.cypress.conclusion == 'failure' && github.ref_name == 'main' }}
         with:
+          webhook-type: incoming-webhook
+          webhook: ${{ secrets.SLACK_HOOK_URL }}
           payload: |
             {
               "text": "⚠️ Cypress E2E failed on Dev\nTriggered by ${{ github.triggering_actor }} \nRun #${{ github.run_number }}: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\nCypress report: ${{ steps.report.outputs.artifact-url }}"
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_HOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/run-e2e-nuclia-prod.yml
+++ b/.github/workflows/run-e2e-nuclia-prod.yml
@@ -134,15 +134,14 @@ jobs:
 
       - name: Send Slack Notification
         if: ${{ steps.collect.outputs.failed_zones != '' && github.ref_name == 'main' }}
-        uses: slackapi/slack-github-action@v1.24.0
+        uses: slackapi/slack-github-action@v2.1.1
         with:
+          webhook-type: incoming-webhook
+          webhook: ${{ secrets.NUA_E2E_SLACK_WEBHOOK }}
           payload: |
             {
               "text": "⚠️ Tests failed in zones: ${{ steps.collect.outputs.failed_zones }}\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.NUA_E2E_SLACK_WEBHOOK }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
       # Always run to check if any zone failed. THis is needed because otherwise the `continue-on-error: true on the test config would make it always a success`
       - name: Mark workflow as failed if any zone failed

--- a/.github/workflows/run-e2e-nuclia-stage.yml
+++ b/.github/workflows/run-e2e-nuclia-stage.yml
@@ -100,12 +100,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Send Slack notification
-        uses: slackapi/slack-github-action@v1.24.0
+        uses: slackapi/slack-github-action@v2.1.1
         with:
+          webhook-type: incoming-webhook
+          webhook: ${{ secrets.NUA_E2E_SLACK_WEBHOOK }}
           payload: |
             {
               "text": "⚠️ Tests failed on STAGE\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.NUA_E2E_SLACK_WEBHOOK }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/run-e2e-prod.yml
+++ b/.github/workflows/run-e2e-prod.yml
@@ -7,8 +7,6 @@ on:
     paths:
       - '.github/workflows/run-e2e-prod.yml'
   workflow_dispatch:
-    branches:
-      - e2e-on-prod
   schedule:
     # Run at minute 45 past every 3rd hour on every day-of-week from Sunday through Saturday.
     - cron: '45 */3 * * 0-6'
@@ -86,13 +84,12 @@ jobs:
           if-no-files-found: ignore
       - name: Slack notification
         id: slack
-        uses: slackapi/slack-github-action@v1.25.0
+        uses: slackapi/slack-github-action@v2.1.1
         if: ${{ failure() && steps.cypress.conclusion == 'failure' }}
         with:
+          webhook-type: incoming-webhook
+          webhook: ${{ secrets.SLACK_HOOK_URL }}
           payload: |
             {
               "text": "‼️️Cypress E2E failed on PROD ‼️\nRun #${{ github.run_number }}: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\nCypress report: ${{ steps.report.outputs.artifact-url }}"
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_HOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/run-e2e-stage.yml
+++ b/.github/workflows/run-e2e-stage.yml
@@ -8,8 +8,6 @@ on:
       - '.github/workflows/run-e2e-stage.yml'
       - 'cypress/**'
   workflow_dispatch:
-    branches:
-      - main
   schedule:
     # Run at 00:25 and 12:25 on saturday and sunday
     - cron: '25 0,12 * * 0,6'
@@ -83,13 +81,12 @@ jobs:
           if-no-files-found: ignore
       - name: Slack notification
         id: slack
-        uses: slackapi/slack-github-action@v1.25.0
+        uses: slackapi/slack-github-action@v2.1.1
         if: ${{ failure() && steps.cypress.conclusion == 'failure' && github.ref_name == 'main' }}
         with:
+          webhook-type: incoming-webhook
+          webhook: ${{ secrets.SLACK_HOOK_URL }}
           payload: |
             {
               "text": "⚠️ Cypress E2E failed on Stage\nTriggered by ${{ github.triggering_actor }} \nRun #${{ github.run_number }}: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\nCypress report: ${{ steps.report.outputs.artifact-url }}"
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_HOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/run-e2e-ui-starter.yml
+++ b/.github/workflows/run-e2e-ui-starter.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - '**'
   workflow_dispatch:
-    branches:
-      - main
   schedule:
     # Run at 00:25 and 12:25 on saturday and sunday
     - cron: '25 0,12 * * 0,6'
@@ -53,13 +51,12 @@ jobs:
           if-no-files-found: ignore # 'warn' or 'error' are also available, defaults to `warn`
       - name: Slack notification
         id: slack
-        uses: slackapi/slack-github-action@v1.25.0
+        uses: slackapi/slack-github-action@v2.1.1
         if: ${{ failure() && steps.cypress.conclusion == 'failure' && github.ref_name == 'main' }}
         with:
+          webhook-type: incoming-webhook
+          webhook: ${{ secrets.SLACK_HOOK_URL }}
           payload: |
             {
               "text": "⚠️ UI Starter E2E failed\nTriggered by ${{ github.triggering_actor }} \nRun #${{ github.run_number }}: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\nCypress report: ${{ steps.report.outputs.artifact-url }}"
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_HOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK


### PR DESCRIPTION
This pull request updates the Slack notification integration across all end-to-end (E2E) workflow files to use the latest version of the Slack GitHub Action and simplifies the configuration for sending notifications. Additionally, it removes branch restrictions from workflow dispatch triggers, making manual workflow runs available from any branch. These changes improve maintainability and flexibility of CI/CD workflows.

**Slack Notification Integration Updates:**

* Upgraded `slackapi/slack-github-action` to version `v2.1.1` in all relevant workflow files, ensuring compatibility and access to new features. [[1]](diffhunk://#diff-8fa186863a2fe0a78a96d18136b3f56f2a46f95d0ef0f19493bfb471bac35cfaL60-L69) [[2]](diffhunk://#diff-bafe2723678f8a55407e80d1a25f8722f5662c4129a5f09c0dc52e21d00b570cL137-L145) [[3]](diffhunk://#diff-6bcd321544d126d2959ec077087618f9e79c7830661dfb3ec7f94dd83d0327a7L103-L111) [[4]](diffhunk://#diff-755ff6ce7f8744f0bb277cb760cdfcee6e4809addfa595fd47fe2de2e97eccbfL89-L98) [[5]](diffhunk://#diff-967f7a10db33a0e30eb6f6edb8af24fc0a49169d3fd36165a46092b94f6d9da4L86-L95) [[6]](diffhunk://#diff-5490291413aba2511d7f1ba45d0c4e4776efca3842bc449905d0290a3ee74c4aL56-L65)
* Replaced the use of environment variables for webhook configuration with direct `with` parameters (`webhook-type` and `webhook`), simplifying the setup and reducing redundancy. [[1]](diffhunk://#diff-8fa186863a2fe0a78a96d18136b3f56f2a46f95d0ef0f19493bfb471bac35cfaL60-L69) [[2]](diffhunk://#diff-bafe2723678f8a55407e80d1a25f8722f5662c4129a5f09c0dc52e21d00b570cL137-L145) [[3]](diffhunk://#diff-6bcd321544d126d2959ec077087618f9e79c7830661dfb3ec7f94dd83d0327a7L103-L111) [[4]](diffhunk://#diff-755ff6ce7f8744f0bb277cb760cdfcee6e4809addfa595fd47fe2de2e97eccbfL89-L98) [[5]](diffhunk://#diff-967f7a10db33a0e30eb6f6edb8af24fc0a49169d3fd36165a46092b94f6d9da4L86-L95) [[6]](diffhunk://#diff-5490291413aba2511d7f1ba45d0c4e4776efca3842bc449905d0290a3ee74c4aL56-L65)

**Workflow Trigger Configuration:**

* Removed branch-specific restrictions from `workflow_dispatch` triggers in all E2E workflow YAML files, allowing manual runs from any branch for increased flexibility. [[1]](diffhunk://#diff-8fa186863a2fe0a78a96d18136b3f56f2a46f95d0ef0f19493bfb471bac35cfaL5-L6) [[2]](diffhunk://#diff-755ff6ce7f8744f0bb277cb760cdfcee6e4809addfa595fd47fe2de2e97eccbfL10-L11) [[3]](diffhunk://#diff-967f7a10db33a0e30eb6f6edb8af24fc0a49169d3fd36165a46092b94f6d9da4L11-L12) [[4]](diffhunk://#diff-5490291413aba2511d7f1ba45d0c4e4776efca3842bc449905d0290a3ee74c4aL8-L9)