### PR TITLE
Proper deletion of rao + fix activity log test

### DIFF
--- a/nuclia_e2e/nuclia_e2e/tests/test_kb_features.py
+++ b/nuclia_e2e/nuclia_e2e/tests/test_kb_features.py
@@ -495,9 +495,9 @@ async def run_test_check_embedding_model_migration(ndb: AsyncNucliaDBClient, tas
         new_embedding_model_available(), max_wait=200, logger=logger
     )
     assert success is True, "embedding migration task did not finish on time"
-    assert search_returned_results is True, (
-        "expected to be able to search with the new embedding model but nucliadb didn't return resources"
-    )
+    assert (
+        search_returned_results is True
+    ), "expected to be able to search with the new embedding model but nucliadb didn't return resources"
 
 
 @backoff.on_exception(backoff.constant, (AssertionError, ClientError), max_tries=5, interval=5)

--- a/nuclia_e2e/nuclia_e2e/tests/test_rao.py
+++ b/nuclia_e2e/nuclia_e2e/tests/test_rao.py
@@ -2,8 +2,8 @@ from nuclia.exceptions import RaoAPIException
 from nuclia.lib.agent import AsyncAgentClient
 from nuclia_e2e.tests.conftest import RegionalAPI
 from nuclia_e2e.tests.conftest import ZoneConfig
-from nuclia_e2e.utils import delete_test_kb
-from nuclia_e2e.utils import get_kbid_from_slug
+from nuclia_e2e.utils import delete_test_agent
+from nuclia_e2e.utils import get_agent_from_slug
 from nuclia_models.agent.interaction import AnswerOperation
 from nuclia_models.agent.interaction import AragAnswer
 
@@ -121,9 +121,9 @@ async def test_rao_basic(regional_api: RegionalAPI, regional_api_config: ZoneCon
     """
     test_slug = f"{regional_api_config.test_kb_slug}-rao-e2e-test"
     # Cleanup any previous test RAO
-    kbid = await get_kbid_from_slug(regional_api_config.zone_slug, test_slug)
-    if kbid is not None:
-        await delete_test_kb(regional_api_config, kbid=kbid, kb_slug=test_slug)
+    agent_id = await get_agent_from_slug(regional_api_config.zone_slug, test_slug)
+    if agent_id is not None:
+        await delete_test_agent(regional_api_config, agent_id=agent_id, agent_slug=test_slug)
     assert regional_api_config.global_config is not None
 
     account = regional_api_config.global_config.permanent_account_id
@@ -160,7 +160,7 @@ async def test_rao_basic(regional_api: RegionalAPI, regional_api_config: ZoneCon
     ):
         responses.append(message)
         assert len(responses) > 0
-    assert responses[0].operation == AnswerOperation.START
+    assert responses[0].operation == AnswerOperation.START, responses[0]
 
     assert responses[1].operation == AnswerOperation.ANSWER
     assert responses[1].step
@@ -193,4 +193,4 @@ async def test_rao_basic(regional_api: RegionalAPI, regional_api_config: ZoneCon
         await agent_client.get_session(sess_id)
 
     # Delete RAO for cleanup
-    await delete_test_kb(regional_api_config, kbid=agent_id, kb_slug=test_slug)
+    await delete_test_agent(regional_api_config, agent_id=agent_id, agent_slug=test_slug)

--- a/nuclia_e2e/nuclia_e2e/utils.py
+++ b/nuclia_e2e/nuclia_e2e/utils.py
@@ -5,6 +5,7 @@ from nuclia.exceptions import NuaAPIException
 from nuclia.lib.kb import AsyncNucliaDBClient
 from nuclia.lib.kb import Environment
 from nuclia.lib.kb import NucliaDBClient
+from nuclia.sdk.agents import AsyncNucliaAgents
 from nuclia.sdk.kbs import AsyncNucliaKBS
 from pathlib import Path
 from tenacity import retry
@@ -55,7 +56,7 @@ async def create_test_kb(regional_api_config, kb_slug, logger: Logger = print) -
 
 async def delete_test_kb(regional_api_config, kbid, kb_slug, logger=print):
     kbs = AsyncNucliaKBS()
-    logger("Deleting kb {kbid}")
+    logger(f"Deleting kb {kbid}")
     await kbs.delete(zone=regional_api_config.zone_slug, id=kbid)
 
     kbid = await get_kbid_from_slug(regional_api_config.zone_slug, kb_slug)
@@ -85,6 +86,21 @@ async def get_kbid_from_slug(zone: str, slug: str) -> str | None:
     kbids_by_slug = {kb.slug: kb.id for kb in all_kbs}
     kbid = kbids_by_slug.get(slug)
     return kbid
+
+
+async def get_agent_from_slug(zone: str, slug: str) -> str | None:
+    agents = AsyncNucliaAgents()
+    all_agents = await agents.list()
+    agentids_by_slug = {agent.slug: agent.id for agent in all_agents}
+    agentid = agentids_by_slug.get(slug)
+    return agentid
+
+
+async def delete_test_agent(regional_api_config, agent_id, agent_slug, logger=print):
+    # Via kbs since AsyncNucliaAgents doesn't have delete method yet
+    agents = AsyncNucliaKBS()
+    logger(f"Deleting agent {agent_id}")
+    await agents.delete(zone=regional_api_config.zone_slug, id=agent_id)
 
 
 class Retriable(Generic[T]):


### PR DESCRIPTION
We were checking only the kbs list so it looked like there wasn't a previously created retrieval agent and we didn't delete it before starting the test

* Fix rao test
* Fix activity log test that was failing