### PR TITLE
Remove llama-3.2-90b-vision-instruct-maas from test models

### DIFF
--- a/nuclia_e2e/nuclia_e2e/models.py
+++ b/nuclia_e2e/nuclia_e2e/models.py
@@ -76,9 +76,6 @@ ALL_LLMS: dict[str, ModelInfo] = {
         test_json=False,  # Structured output not working
     ),
     # "huggingface"                          EXCLUDED as not a model,just a driver, that needs a key to work
-    "llama-3.2-90b-vision-instruct-maas": ModelInfo(
-        test_json=False,  # Json functionality not operational
-    ),
     "llama-4-maverick-17b-128e-instruct-maas": ModelInfo(
         test_json=False,  # Json functionality not operational
     ),


### PR DESCRIPTION
- Remove model from ALL_LLMS dictionary to prevent e2e test failures

Part of model deprecation migration. Related PRs:
- learning: https://github.com/nuclia/learning/pull/3008
- core-apps: https://github.com/nuclia/core-apps/pull/6549