### PR TITLE
Update model list: "gemini-3-pro" -> "gemini-3.1-pro"

### DIFF
--- a/nuclia_e2e/nuclia_e2e/models.py
+++ b/nuclia_e2e/nuclia_e2e/models.py
@@ -54,7 +54,8 @@ ALL_LLMS: dict[str, ModelInfo] = {
     "gemini-2.5-pro": ModelInfo(),
     "gemini-2.5-flash": ModelInfo(),
     "gemini-2.5-flash-lite": ModelInfo(),
-    "gemini-3-pro": ModelInfo(),
+    # "gemini-3-pro": ModelInfo(),            DISCONTINUED
+    "gemini-3.1-pro": ModelInfo(),
     # "mistral": ModelInfo(est_json=False,),  DISCONTINUED
     # "azure-mistral",                       DISCONTINUED
     "chatgpt4o": ModelInfo(),


### PR DESCRIPTION
Replace `gemini-3-pro` with `gemini-3.1-pro` in the E2E model matrix so tests run against the new Gemini preview model during the migration.
