### PR TITLE
Update grafana URL to https://grafana.gcp-internal-1.nuclia.cloud/

### DIFF
--- a/nuclia_e2e/nuclia_e2e/tests/conftest.py
+++ b/nuclia_e2e/nuclia_e2e/tests/conftest.py
@@ -95,7 +95,7 @@ CLUSTERS_CONFIG = {
             gmail_app_password=settings.test_gmail_app_password,
             permanent_account_slug="automated-testing",
             permanent_account_id="8c7db65c-3b7e-4140-8165-d37bb4e6e9b8",
-            grafana_url="http://platform.grafana.nuclia.com",
+            grafana_url="https://grafana.gcp-internal-1.nuclia.cloud/",
             tempo_datasource_id=TEMPO_DATASOURCE_ID,
         ),
         zones=[


### PR DESCRIPTION
This pull request updates the Grafana URL used in the `ClusterConfig` class to point to a new internal address. This ensures that monitoring and dashboarding tools reference the correct, current environment.

- Configuration update:
  * Changed the `grafana_url` in the `ClusterConfig` class from `http://platform.grafana.nuclia.com` to `https://grafana.gcp-internal-1.nuclia.cloud/` to use the new internal Grafana instance.