### PR TITLE
Add new region to e2e

### DIFF
--- a/.github/workflows/run-e2e-nuclia-prod.yml
+++ b/.github/workflows/run-e2e-nuclia-prod.yml
@@ -69,7 +69,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        zone: [gke-prod-1, aws-us-east-2-1, aws-il-central-1-1, aws-eu-central-1-1] # Remove aws-me-central-1-1 due to rocket issue
+        zone: [gke-prod-1, aws-us-east-2-1, aws-il-central-1-1, aws-eu-central-1-1, aws-ap-southeast-2-1] # Remove aws-me-central-1-1 due to rocket issue
         shard_index: [0, 1, 2]  # Running tests in 3 parallel shards
     needs:
       - build-virtual-env
@@ -98,6 +98,7 @@ jobs:
           PROD_AWS_IL_CENTRAL_1_1_NUA: ${{ secrets.PROD_AWS_IL_CENTRAL_1_1_NUA }}
           PROD_AWS_EU_CENTRAL_1_1_NUA: ${{ secrets.PROD_AWS_EU_CENTRAL_1_1_NUA }}
           PROD_AWS_ME_CENTRAL_1_1_NUA: ${{ secrets.PROD_AWS_ME_CENTRAL_1_1_NUA }}
+          PROD_AWS_AP_SOUTHEAST_2_1_NUA: ${{ secrets.PROD_AWS_AP_SOUTHEAST_2_1_NUA }}
           TEST_GMAIL_APP_PASSWORD: ${{ secrets.TEST_GMAIL_APP_PASSWORD }}
           GOOGLE_DRIVE_CLIENT_SECRET: ${{ secrets.GOOGLE_DRIVE_CLIENT_SECRET }}
           GOOGLE_DRIVE_REFRESH_TOKEN: ${{ secrets.GOOGLE_DRIVE_REFRESH_TOKEN }}

--- a/nuclia_e2e/nuclia_e2e/settings.py
+++ b/nuclia_e2e/nuclia_e2e/settings.py
@@ -24,6 +24,7 @@ class E2ESettings(BaseSettings):
     prod_aws_il_central_1_1_nua: str = ""
     prod_aws_eu_central_1_1_nua: str = ""
     prod_aws_me_central_1_1_nua: str = ""
+    prod_aws_ap_southeast_2_1_nua: str = ""
 
     # Stage environment
     stage_global_recaptcha: str = ""
@@ -73,6 +74,7 @@ class E2ESettings(BaseSettings):
                 "prod_aws_il_central_1_1_nua",
                 "prod_aws_eu_central_1_1_nua",
                 "prod_aws_me_central_1_1_nua",
+                "prod_aws_ap_southeast_2_1_nua",
             ]
         elif env == "stage":
             fields = [

--- a/nuclia_e2e/nuclia_e2e/tests/conftest.py
+++ b/nuclia_e2e/nuclia_e2e/tests/conftest.py
@@ -134,6 +134,13 @@ CLUSTERS_CONFIG = {
                 permanent_kb_slug="pre-existing-kb",
                 permanent_nua_key=settings.prod_aws_me_central_1_1_nua,
             ),
+            ZoneConfig(
+                name="aws-ap-southeast-2-1",
+                zone_slug="aws-ap-southeast-2-1",
+                test_kb_slug="nuclia-e2e-live-aws-ap-southeast-2-1",
+                permanent_kb_slug="pre-existing-kb",
+                permanent_nua_key=settings.prod_aws_ap_southeast_2_1_nua,
+            ),
         ],
     ),
     "stage": ClusterConfig(


### PR DESCRIPTION
This pull request updates the end-to-end (E2E) workflow configuration to add support for the `aws-ap-southeast-2-1` zone. The main changes ensure that E2E tests will now also run in this additional zone and that the necessary secrets are available for it.

**E2E workflow enhancements:**

* Added `aws-ap-southeast-2-1` to the test matrix in the `zone` list, so E2E tests will run in this new zone.
* Added the `PROD_AWS_AP_SOUTHEAST_2_1_NUA` secret to the environment variables to support authentication in the new zone.