### PR TITLE
Remove warnings related to node20

### DIFF
--- a/.github/workflows/run-e2e-nuclia-prod.yml
+++ b/.github/workflows/run-e2e-nuclia-prod.yml
@@ -23,7 +23,7 @@ jobs:
           persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 
       - name: Install venv
         run: uv sync --project nuclia_e2e

--- a/.github/workflows/run-e2e-nuclia-stage.yml
+++ b/.github/workflows/run-e2e-nuclia-stage.yml
@@ -25,7 +25,7 @@ jobs:
           persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 
       - name: Install venv
         run: uv sync --project nuclia_e2e


### PR DESCRIPTION
This pull request updates the version of the `astral-sh/setup-uv` GitHub Action used in the end-to-end workflow files. The action is upgraded from version 5.4.2 to 8.2.0 to ensure the workflows use the latest features and fixes.

**Workflow dependency update:**

* Upgraded the `astral-sh/setup-uv` action from `v5.4.2` to `v8.2.0` in both `.github/workflows/run-e2e-nuclia-prod.yml` [[1]](diffhunk://#diff-bafe2723678f8a55407e80d1a25f8722f5662c4129a5f09c0dc52e21d00b570cL26-R26) and `.github/workflows/run-e2e-nuclia-stage.yml` [[2]](diffhunk://#diff-6bcd321544d126d2959ec077087618f9e79c7830661dfb3ec7f94dd83d0327a7L28-R28).