### PR TITLE
Update Grafana URL

### DIFF
--- a/nuclia_e2e/nuclia_e2e/tests/conftest.py
+++ b/nuclia_e2e/nuclia_e2e/tests/conftest.py
@@ -153,7 +153,7 @@ CLUSTERS_CONFIG = {
             gmail_app_password=settings.test_gmail_app_password,
             permanent_account_slug="automated-testing",
             permanent_account_id="f2edd58e-431f-4197-be76-6fc611082fe8",
-            grafana_url="http://platform.grafana.nuclia.com",
+            grafana_url="https://grafana.gcp-internal-1.nuclia.cloud",
             tempo_datasource_id=TEMPO_DATASOURCE_ID,
         ),
         zones=[


### PR DESCRIPTION
This pull request makes a minor update to the `ClusterConfig` in the `conftest.py` file, changing the URL used for Grafana monitoring.

- Changed the `grafana_url` in the `ClusterConfig` from `http://platform.grafana.nuclia.com` to `https://grafana.gcp-internal-1.nuclia.cloud` to point to the new internal Grafana instance.